### PR TITLE
Detect GPU automatically + the rendering framebuffer was not created …

### DIFF
--- a/Project/Source/Main.cpp
+++ b/Project/Source/Main.cpp
@@ -8,6 +8,12 @@
 
 #include "Utils/Leaks.h"
 
+// Use discrete GPU by default.
+extern "C" {
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) unsigned long AmdPowerXpressRequestHighPerformance = 0x00000001;
+}
+
 enum class MainState {
 	CREATION,
 	INIT,

--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -132,7 +132,9 @@ bool ModuleRender::Init() {
 	glGenRenderbuffers(1, &depthRenderbuffer);
 	glGenTextures(1, &renderTexture);
 
+
 	ViewportResized(200, 200);
+	UpdateFramebuffer();
 
 	return true;
 }
@@ -221,23 +223,7 @@ UpdateStatus ModuleRender::PostUpdate() {
 
 #if !GAME
 	if (viewportUpdated) {
-		// Framebuffer calculations
-		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
-
-		glBindTexture(GL_TEXTURE_2D, renderTexture);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, viewportSize.x, viewportSize.y, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, renderTexture, 0);
-
-		glBindRenderbuffer(GL_RENDERBUFFER, depthRenderbuffer);
-		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, viewportSize.x, viewportSize.y);
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthRenderbuffer);
-
-		if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-			LOG("ERROR: Framebuffer is not complete!");
-		}
-
+		UpdateFramebuffer();
 		viewportUpdated = false;
 	}
 #endif
@@ -260,6 +246,24 @@ void ModuleRender::ViewportResized(int width, int height) {
 	viewportSize.y = height;
 
 	viewportUpdated = true;
+}
+
+void ModuleRender::UpdateFramebuffer() {
+	glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+
+	glBindTexture(GL_TEXTURE_2D, renderTexture);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, viewportSize.x, viewportSize.y, 0, GL_RGB, GL_UNSIGNED_BYTE, NULL);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, renderTexture, 0);
+
+	glBindRenderbuffer(GL_RENDERBUFFER, depthRenderbuffer);
+	glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8, viewportSize.x, viewportSize.y);
+	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthRenderbuffer);
+
+	if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+		LOG("ERROR: Framebuffer is not complete!");
+	}
 }
 
 void ModuleRender::SetVSync(bool vsync) {

--- a/Project/Source/Modules/ModuleRender.h
+++ b/Project/Source/Modules/ModuleRender.h
@@ -17,7 +17,8 @@ public:
 	UpdateStatus PostUpdate() override;
 	bool CleanUp() override;
 
-	void ViewportResized(int width, int height);
+	void ViewportResized(int width, int height); // Updates the viewport aspect ratio with the new one given by parameters. It will set 'viewportUpdated' to true, to regenerate the framebuffer to its new size using UpdateFramebuffer().
+	void UpdateFramebuffer();					 // Generates the rendering framebuffer on Init(). If 'viewportUpdated' was set to true, it will be also called at PostUpdate().
 
 	void SetVSync(bool vsync);
 


### PR DESCRIPTION
Detecting GPU automatically.

Test by setting NVIDIA "procesador de graficos preferido"->"Graficos integrados", and check if the GPU is detected (In hardware configuration panel).
Comment the new code in Main.cpp and check if then detects the integrated card.

EXTRA FIX: Solved an invisible issue where the framebuffer did not exist for the 1st frame. (The buffer was created at the 1st PostUpdate)