### PR TITLE
Fixed bug where ScreenFactor was 1 (absolute) when loading a scene

### DIFF
--- a/Project/Source/Components/UI/ComponentCanvas.cpp
+++ b/Project/Source/Components/UI/ComponentCanvas.cpp
@@ -11,6 +11,7 @@
 #include "Utils/Leaks.h"
 
 void ComponentCanvas::Init() {
+	
 }
 
 void ComponentCanvas::Save(JsonValue jComponent) const {
@@ -24,6 +25,8 @@ void ComponentCanvas::Update() {
 }
 
 void ComponentCanvas::Load(JsonValue jComponent) {
+	// Needs to be called before Init, otherwise other components that use the screen factor, won't have it
+	RecalculateScreenFactor();
 }
 
 void ComponentCanvas::DuplicateComponent(GameObject& owner) {

--- a/Project/Source/Components/UI/ComponentText.cpp
+++ b/Project/Source/Components/UI/ComponentText.cpp
@@ -43,6 +43,7 @@ void ComponentText::Init() {
 	glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), 0);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 	glBindVertexArray(0);
+	RecalculcateVertices();
 }
 
 void ComponentText::OnEditorUpdate() {
@@ -111,8 +112,6 @@ void ComponentText::Load(JsonValue jComponent) {
 
 	JsonValue jColor = jComponent[JSON_TAG_COLOR];
 	color.Set(jColor[0], jColor[1], jColor[2], jColor[3]);
-
-	RecalculcateVertices();
 }
 
 void ComponentText::DuplicateComponent(GameObject& owner) {


### PR DESCRIPTION
This makes other Components load with an initial incorrect size (p.eg: ComponentText)