### PR TITLE
ComponentImage will use ComponentSelectable Main color as main color

### DIFF
--- a/Game/Assets/Shaders/ImageUI.shader
+++ b/Game/Assets/Shaders/ImageUI.shader
@@ -22,11 +22,10 @@ in vec2 uv0;
 uniform sampler2D diffuse;
 uniform int hasDiffuse;
 uniform vec4 inputColor;
-uniform vec4 tintColor;
 
 out vec4 outColor;
 
 void main()
 {	
-	outColor = (hasDiffuse * texture2D(diffuse, uv0) + 1 - hasDiffuse) * inputColor * tintColor;
+	outColor = (hasDiffuse * texture2D(diffuse, uv0) + 1 - hasDiffuse) * inputColor;
 }

--- a/Project/Source/Components/UI/ComponentButton.cpp
+++ b/Project/Source/Components/UI/ComponentButton.cpp
@@ -73,7 +73,7 @@ float4 ComponentButton::GetTintColor() const {
 
 	ComponentSelectable* sel = GetOwner().GetComponent<ComponentSelectable>();
 
-	if (!sel) App->userInterface->GetErrorColor();
+	if (!sel) return App->userInterface->GetErrorColor();
 
 	if (sel->GetTransitionType() == ComponentSelectable::TransitionType::COLOR_CHANGE) {
 		if (!sel->IsInteractable()) {

--- a/Project/Source/Components/UI/ComponentButton.cpp
+++ b/Project/Source/Components/UI/ComponentButton.cpp
@@ -69,11 +69,11 @@ float4 ComponentButton::GetClickColor() const {
 }
 
 float4 ComponentButton::GetTintColor() const {
-	if (!IsActive()) return float4::one;
+	if (!IsActive()) return App->userInterface->GetErrorColor();
 
 	ComponentSelectable* sel = GetOwner().GetComponent<ComponentSelectable>();
 
-	if (!sel) return float4::one;
+	if (!sel) App->userInterface->GetErrorColor();
 
 	if (sel->GetTransitionType() == ComponentSelectable::TransitionType::COLOR_CHANGE) {
 		if (!sel->IsInteractable()) {
@@ -87,7 +87,7 @@ float4 ComponentButton::GetTintColor() const {
 		}
 	}
 
-	return float4::one;
+	return App->userInterface->GetErrorColor();
 }
 
 void ComponentButton::DuplicateComponent(GameObject& owner) {

--- a/Project/Source/Components/UI/ComponentImage.cpp
+++ b/Project/Source/Components/UI/ComponentImage.cpp
@@ -97,25 +97,26 @@ void ComponentImage::Load(JsonValue jComponent) {
 	alphaTransparency = jComponent[JSON_TAG_ALPHATRANSPARENCY];
 }
 
-float4 ComponentImage::GetTintColor() const {
+float4 ComponentImage::GetMainColor() const {
+
+	float4 componentColor = App->userInterface->GetErrorColor();
+
 	ComponentButton* button = GetOwner().GetComponent<ComponentButton>();
 	if (button != nullptr) {
-		return button->GetTintColor();
+		componentColor = button->GetTintColor();
 	}
-	GameObject* sliderParent = GetOwner().GetParent();
-	if (sliderParent != nullptr) {
-		ComponentSlider* slider = sliderParent->GetComponent<ComponentSlider>();
-		if (slider != nullptr) {
-			return slider->GetTintColor();
-		}
+
+	ComponentSlider* slider = GetOwner().GetComponent<ComponentSlider>();
+	if (slider != nullptr) {
+		componentColor = slider->GetTintColor();
 	}
 
 	ComponentToggle* toggle = GetOwner().GetComponent<ComponentToggle>();
 	if (toggle != nullptr) {
-		return toggle->GetTintColor();
+		componentColor = toggle->GetTintColor();
 	}
-
-	return float4::one;
+	
+	return componentColor.Equals(App->userInterface->GetErrorColor()) ? color : componentColor;
 }
 
 void ComponentImage::Draw(const ComponentTransform2D* transform) const {
@@ -152,8 +153,7 @@ void ComponentImage::Draw(const ComponentTransform2D* transform) const {
 
 	glActiveTexture(GL_TEXTURE0);
 	glUniform1i(glGetUniformLocation(program, "diffuse"), 0);
-	glUniform4fv(glGetUniformLocation(program, "inputColor"), 1, color.ptr());
-	glUniform4fv(glGetUniformLocation(program, "tintColor"), 1, GetTintColor().ptr());
+	glUniform4fv(glGetUniformLocation(program, "inputColor"), 1, GetMainColor().ptr());
 
 	ResourceTexture* textureResource = App->resources->GetResource<ResourceTexture>(textureID);
 	if (textureResource != nullptr) {

--- a/Project/Source/Components/UI/ComponentImage.h
+++ b/Project/Source/Components/UI/ComponentImage.h
@@ -24,7 +24,7 @@ public:
 	void SetColor(float4 color_);
 
 private:
-	float4 GetTintColor() const; // Gets an additional color that needs to be applied to the image. Currently gets the color of the Button
+	float4 GetMainColor() const;	// Gets an additional color that needs to be applied to the image. Currently gets the color of the Button, Slider and Checkbox
 
 private:
 	float4 color = float4::one;		// Color used as default tainter

--- a/Project/Source/Components/UI/ComponentSlider.cpp
+++ b/Project/Source/Components/UI/ComponentSlider.cpp
@@ -207,11 +207,11 @@ float2 ComponentSlider::GetClickedPosition() const {
 }
 
 float4 ComponentSlider::GetTintColor() const {
-	if (!IsActive()) return float4::one;
+	if (!IsActive()) return App->userInterface->GetErrorColor();
 
 	ComponentSelectable* sel = GetOwner().GetComponent<ComponentSelectable>();
 
-	if (!sel) return float4::one;
+	if (!sel) return App->userInterface->GetErrorColor();
 
 	if (sel->GetTransitionType() == ComponentSelectable::TransitionType::COLOR_CHANGE) {
 		if (!sel->IsInteractable()) {
@@ -225,7 +225,7 @@ float4 ComponentSlider::GetTintColor() const {
 		}
 	}
 
-	return float4::one;
+	return App->userInterface->GetErrorColor();
 }
 
 void ComponentSlider::SetNormalizedValue() {

--- a/Project/Source/Components/UI/ComponentToggle.cpp
+++ b/Project/Source/Components/UI/ComponentToggle.cpp
@@ -78,11 +78,11 @@ void ComponentToggle::SetClicked(bool clicked_) {
 }
 
 float4 ComponentToggle::GetTintColor() const {
-	if (!IsActive()) return float4::one;
+	if (!IsActive()) return App->userInterface->GetErrorColor();
 
 	ComponentSelectable* sel = GetOwner().GetComponent<ComponentSelectable>();
 
-	if (!sel) return float4::one;
+	if (!sel) return App->userInterface->GetErrorColor();
 
 	if (sel->GetTransitionType() == ComponentSelectable::TransitionType::COLOR_CHANGE) {
 		if (!sel->IsInteractable()) {
@@ -96,7 +96,7 @@ float4 ComponentToggle::GetTintColor() const {
 		}
 	}
 
-	return float4::one;
+	return App->userInterface->GetErrorColor();
 }
 
 float4 ComponentToggle::GetClickColor() const {

--- a/Project/Source/Modules/ModuleUserInterface.cpp
+++ b/Project/Source/Modules/ModuleUserInterface.cpp
@@ -218,3 +218,7 @@ void ModuleUserInterface::ViewportResized() {
 		text.RecalculcateVertices();
 	}
 }
+
+float4 ModuleUserInterface::GetErrorColor() {
+	return errorColor;
+}

--- a/Project/Source/Modules/ModuleUserInterface.h
+++ b/Project/Source/Modules/ModuleUserInterface.h
@@ -3,6 +3,7 @@
 #include "Module.h"
 #include "Utils/UID.h"
 #include "Math/float2.h"
+#include "Math/float4.h"
 
 class GameObject;
 class ComponentEventSystem;
@@ -27,10 +28,13 @@ public:
 	unsigned int GetQuadVBO();			// Returns the generic VBO that is used in ComponentImages
 	void ViewportResized();				// Calls ComponentCanvas, ComponentTransform2D, ComponentText components to be updated
 
+	float4 GetErrorColor();				// Gets the representation of the color
+
 private:
 	void CreateQuadVBO();				// Creates a vbo made by two triangles centered that form a Quad
 
 private:
 	UID currentEvSys = 0;				// Module's Event System UID
 	unsigned int quadVBO = 0;			// VBO of the ComponentImage generic Quad
+	float4 errorColor = float4(-1, -1, -1, -1);		// Representation of error in color (not a color to display)
 };


### PR DESCRIPTION
Tint Color has been removed from Shader and ComponentImage uses the main color of the ComponentSelectable in case it needs it (p.eg: when Selectable is hovered, selected or clicked).

As is:
ComponentImage has a color, and ComponentSelectable was used as a tint on the color.

To be:
If ComponentImage has a button, slider or toggle, will use their current state color as main color instead of tint.