### PR TITLE
Hotfix: UI Components updated in the viewport at the same time that in the hierarchy 

### DIFF
--- a/Project/Source/GameObject.cpp
+++ b/Project/Source/GameObject.cpp
@@ -114,6 +114,12 @@ void GameObject::SetParent(GameObject* gameObject) {
 	if (gameObject != nullptr) {
 		gameObject->children.push_back(this);
 	}
+
+	// To invalidate hierarchy in UIElements
+	ComponentTransform2D* parentTransform2D = this->GetComponent<ComponentTransform2D>();
+	if (parentTransform2D != nullptr) {
+		parentTransform2D->InvalidateHierarchy();
+	}
 }
 
 GameObject* GameObject::GetParent() const {


### PR DESCRIPTION
Fixed! Right now the UIComponents are updated in the viewport at the same time changes the hierarchy between them.

PD: Sorry for the name of the branch, I believed that only happen this problem with UIText XD

![Debug 2021 05 11 - 21 02 20 01](https://user-images.githubusercontent.com/25251729/117871294-81124580-b29d-11eb-8416-bf7115e8f891.gif)

