### PR TITLE
Fix shaders / Modify ResourceMaterial

### DIFF
--- a/Game/Assets/Shaders/fragmentPhong.shader
+++ b/Game/Assets/Shaders/fragmentPhong.shader
@@ -1,18 +1,19 @@
 --- fragMainPhong
 
-void main() {
+void main() 
+{
 
-    vec3 viewN = normalize(viewPos - fragPos);
-    vec2 tiledUV = GetTiledUVs(uv, tiling, offset); 
+    vec3 viewDir = normalize(viewPos - fragPos);
+    vec2 tiledUV = GetTiledUVs(); 
     vec3 normal = fragNormal;
 
     if (hasNormalMap)
     {
-	    normal = GetNormal(normalMap, tiledUV, TBN, normalStrength);
+	    normal = GetNormal(tiledUV);
     }
 
     // diffuse
-    vec4 colorDiffuse = GetDiffuse(diffuseMap, tiledUV, diffuseColor, hasDiffuseMap);
+    vec4 colorDiffuse = GetDiffuse(tiledUV);
 
     // specular
     vec4 colorSpecular = hasSpecularMap * pow(texture(specularMap, tiledUV), vec4(2.2)) + (1 - hasSpecularMap) * vec4(specularColor, 1.0);
@@ -22,9 +23,9 @@ void main() {
     float shininess = hasSmoothnessAlpha * exp2(colorSpecular.a * 7 + 1) + (1 - hasSmoothnessAlpha) * smoothness;
 
     // Ambient Color
-    vec3 ambientColor = colorDiffuse.rgb * light.ambient.color;
+    vec3 colorAmbient = GetAmbientOcclusion(tiledUV);
 
-    vec3 accumulativeColor = ambientColor;
+    vec3 colorAccumulative = colorDiffuse.rgb * colorAmbient;
 
     // Directional Light
     if (light.directional.isActive == 1) {
@@ -32,14 +33,14 @@ void main() {
         float NL = max(dot(normal, - directionalDir), 0.0);
 
         vec3 reflectDir = reflect(directionalDir, normal);
-        float VRn = pow(max(dot(viewN, reflectDir), 0.0), shininess);
+        float VRn = pow(max(dot(viewDir, reflectDir), 0.0), shininess);
 
 
         vec3 Rf = Rf0 + (1 - Rf0) * pow(1 - NL, 5);
 
         vec3 directionalColor = (colorDiffuse.rgb * (1 - Rf0) + (shininess + 2) / 2 * Rf * VRn) * light.directional.color * light.directional.intensity * NL;
 
-        accumulativeColor = accumulativeColor + directionalColor;
+        colorAccumulative += directionalColor;
     }
 
     // Point Light
@@ -51,13 +52,13 @@ void main() {
         float NL = max(dot(normal, -pointDir), 0.0);
 
         vec3 reflectDir = reflect(pointDir, normal);
-        float VRn = pow(max(dot(viewN, reflectDir), 0.0), shininess);
+        float VRn = pow(max(dot(viewDir, reflectDir), 0.0), shininess);
 
         vec3 Rf = Rf0 + (1 - Rf0) * pow(1 - NL, 5);
 
         vec3 pointColor = (colorDiffuse.rgb * (1 - Rf0) + (shininess + 2) / 2 * Rf * VRn) * light.points[i].color * light.points[i].intensity * distAttenuation * NL;
 
-        accumulativeColor = accumulativeColor + pointColor;
+        colorAccumulative += pointColor;
     }
 
     // Spot Light
@@ -81,16 +82,19 @@ void main() {
         float NL = max(dot(normal, -spotDir), 0.0);
 
         vec3 reflectDir = reflect(spotDir, normal);
-        float VRn = pow(max(dot(viewN, reflectDir), 0.0), shininess);
+        float VRn = pow(max(dot(viewDir, reflectDir), 0.0), shininess);
 
         vec3 Rf = Rf0 + (1 - Rf0) * pow(1 - NL, 5);
 
         vec3 spotColor = (colorDiffuse.rgb * (1 - Rf0) + (shininess + 2) / 2 * Rf * VRn) * light.spots[i].color * light.spots[i].intensity * distAttenuation * cAttenuation * NL;
 
-        accumulativeColor = accumulativeColor + spotColor;
+        colorAccumulative += spotColor;
     }
 
-    vec3 ldr = accumulativeColor.rgb / (accumulativeColor.rgb + vec3(1.0)); // reinhard tone mapping
+    // Emission
+    colorAccumulative += GetEmissive(tiledUV).rgb;
+
+    vec3 ldr = colorAccumulative.rgb / (colorAccumulative.rgb + vec3(1.0)); // reinhard tone mapping
     ldr = pow(ldr, vec3(1/2.2)); // gamma correction
     outColor = vec4(ldr, 1.0);
 }

--- a/Game/Assets/Shaders/fragmentStandard.shader
+++ b/Game/Assets/Shaders/fragmentStandard.shader
@@ -80,25 +80,30 @@ float Pow2(float a)
     return a * a;
 }
 
-vec2 GetTiledUVs(vec2 uv, vec2 tiling, vec2 offset)
+vec2 GetTiledUVs()
 {
     return uv * tiling + offset; 
 }
 
-vec4 GetDiffuse(sampler2D diffuseMap, vec2 uv, vec3 diffuseColor, int hasDiffuseMap)
+vec4 GetDiffuse(vec2 tiledUV)
 {
-    return hasDiffuseMap * pow(texture(diffuseMap, uv), vec4(2.2)) * vec4(diffuseColor, 1.0) + (1 - hasDiffuseMap) * vec4(diffuseColor, 1.0);
+    return hasDiffuseMap * pow(texture(diffuseMap, tiledUV), vec4(2.2)) * vec4(diffuseColor, 1.0) + (1 - hasDiffuseMap) * vec4(diffuseColor, 1.0);
 }
 
-vec4 GetEmissive(sampler2D emissiveMap, vec2 uv, int hasEmissiveMap)
+vec4 GetEmissive(vec2 tiledUV)
 {
-    return hasEmissiveMap * pow(texture(emissiveMap, uv), vec4(2.2));
+    return hasEmissiveMap * pow(texture(emissiveMap, tiledUV), vec4(2.2));
 }
 
-vec3 GetNormal(sampler2D normalMap, vec2 uv, mat3 TBN, float normalStrength)
+vec3 GetAmbientOcclusion(vec2 tiledUV)
+{
+    return hasAmbientOcclusionMap * light.ambient.color * texture(ambientOcclusionMap, tiledUV).rgb + (1 - hasAmbientOcclusionMap) * light.ambient.color;
+}
+
+vec3 GetNormal(vec2 tiledUV)
 {
 
-    vec3 normal = texture(normalMap, uv).rgb;
+    vec3 normal = texture(normalMap, tiledUV).rgb;
     normal = normal * 2.0 - 1.0;
     normal.xy *= normalStrength;
     normal = normalize(normal);
@@ -152,7 +157,7 @@ vec3 ProcessDirectionalLight(DirLight directional, vec3 fragNormal, vec3 viewDir
     return (Cd * (1 - F0) + 0.25 * Fn * V * NDF) * directional.color * directional.intensity * NL;
 }
 
-vec3 ProcessPointLight(PointLight point, vec3 fragNormal, vec3 fragPos, vec3 viewDir, vec3 Cd, vec3 F0, float roughness)
+vec3 ProcessPointLight(PointLight point, vec3 fragNormal, vec3 viewDir, vec3 Cd, vec3 F0, float roughness)
 {
     float pointDistance = length(point.pos - fragPos);
     float distAttenuation = 1.0 / (point.kc + point.kl * pointDistance + point.kq * pointDistance * pointDistance);
@@ -173,7 +178,7 @@ vec3 ProcessPointLight(PointLight point, vec3 fragNormal, vec3 fragPos, vec3 vie
     return (Cd * (1 - F0) + 0.25 * Fn * V * NDF) * point.color * point.intensity * distAttenuation * NL;
 }
 
-vec3 ProcessSpotLight(SpotLight spot, vec3 fragNormal, vec3 fragPos, vec3 viewDir, vec3 Cd, vec3 F0, float roughness)
+vec3 ProcessSpotLight(SpotLight spot, vec3 fragNormal, vec3 viewDir, vec3 Cd, vec3 F0, float roughness)
 {
     float spotDistance = length(spot.pos - fragPos);
 	float distAttenuation = 1.0 / (spot.kc + spot.kl * spotDistance + spot.kq * spotDistance * spotDistance);
@@ -213,22 +218,22 @@ vec3 ProcessSpotLight(SpotLight spot, vec3 fragNormal, vec3 fragPos, vec3 viewDi
 void main()
 {    
     vec3 viewDir = normalize(viewPos - fragPos);
-    vec2 tiledUV = GetTiledUVs(uv, tiling, offset); 
+    vec2 tiledUV = GetTiledUVs(); 
     vec3 normal = fragNormal;
 
     if (hasNormalMap)
     {
-	    normal = GetNormal(normalMap, tiledUV, TBN, normalStrength);
+	    normal = GetNormal(tiledUV);
     }
 
-    vec4 colorDiffuse = GetDiffuse(diffuseMap, tiledUV, diffuseColor, hasDiffuseMap);
+    vec4 colorDiffuse = GetDiffuse(tiledUV);
     vec4 colorMetallic = pow(texture(metallicMap, tiledUV), vec4(2.2));
     float metalnessMask = hasMetallicMap * colorMetallic.r + (1 - hasMetallicMap) * metalness;
 
     float roughness = Pow2(1 - smoothness * (hasSmoothnessAlpha * colorMetallic.a + (1 - hasSmoothnessAlpha) * colorDiffuse.a)) + EPSILON;
 
     // Ambient Occlusion
-    vec3 colorAmbient = hasAmbientOcclusionMap * light.ambient.color * texture(ambientOcclusionMap, uv).rgb + (1 - hasAmbientOcclusionMap) * light.ambient.color;
+    vec3 colorAmbient = GetAmbientOcclusion(tiledUV);
 
     vec3 colorAccumulative = colorDiffuse.rgb * colorAmbient;
 
@@ -245,17 +250,17 @@ void main()
 	// Point Light
 	for (int i = 0; i < light.numPoints; i++)
 	{
-    	colorAccumulative += ProcessPointLight(light.points[i], normal, fragPos, viewDir, Cd, F0, roughness);
+    	colorAccumulative += ProcessPointLight(light.points[i], normal, viewDir, Cd, F0, roughness);
 	}
 
     // Spot Light
 	for (int i = 0; i < light.numSpots; i++)
 	{
-    	colorAccumulative += ProcessSpotLight(light.spots[i], normal, fragPos, viewDir, Cd, F0, roughness);
+    	colorAccumulative += ProcessSpotLight(light.spots[i], normal, viewDir, Cd, F0, roughness);
 	}
 
     // Emission
-    colorAccumulative += GetEmissive(emissiveMap, uv, hasEmissiveMap).rgb;
+    colorAccumulative += GetEmissive(tiledUV).rgb;
 
     vec3 ldr = colorAccumulative.rgb / (colorAccumulative.rgb + vec3(1.0)); // reinhard tone mapping
 	ldr = pow(ldr, vec3(1/2.2)); // gamma correction
@@ -267,21 +272,21 @@ void main()
 void main()
 {    
     vec3 viewDir = normalize(viewPos - fragPos);
-    vec2 tiledUV = GetTiledUVs(uv, tiling, offset); 
+    vec2 tiledUV = GetTiledUVs(); 
     vec3 normal = fragNormal;
 
     if (hasNormalMap)
     {
-	    normal = GetNormal(normalMap, tiledUV, TBN, normalStrength);
+	    normal = GetNormal(tiledUV);
     }
 	
-    vec4 colorDiffuse = GetDiffuse(diffuseMap, tiledUV, diffuseColor, hasDiffuseMap);
+    vec4 colorDiffuse = GetDiffuse(tiledUV);
     vec4 colorSpecular = hasSpecularMap * pow(texture(specularMap, tiledUV), vec4(2.2)) + (1 - hasSpecularMap) * vec4(specularColor, 1.0);
 
     float roughness = Pow2(1 - smoothness * (hasSmoothnessAlpha * colorSpecular.a + (1 - hasSmoothnessAlpha) * colorDiffuse.a)) + EPSILON;
     
     // Ambient Occlusion
-    vec3 colorAmbient = hasAmbientOcclusionMap * light.ambient.color * texture(ambientOcclusionMap, uv).rgb + (1 - hasAmbientOcclusionMap) * light.ambient.color;
+    vec3 colorAmbient = GetAmbientOcclusion(tiledUV);
 
     vec3 colorAccumulative = colorDiffuse.rgb * colorAmbient;
 
@@ -294,17 +299,17 @@ void main()
 	// Point Light
     for(int i = 0; i < light.numPoints; i++)
     {
-        colorAccumulative += ProcessPointLight(light.points[i], normal, fragPos, viewDir, colorDiffuse.rgb, colorSpecular.rgb, roughness);
+        colorAccumulative += ProcessPointLight(light.points[i], normal, viewDir, colorDiffuse.rgb, colorSpecular.rgb, roughness);
     }
 
     // Spot Light
     for(int i = 0; i < light.numSpots; i++)
     {
-        colorAccumulative += ProcessSpotLight(light.spots[i], normal, fragPos, viewDir, colorDiffuse.rgb, colorSpecular.rgb, roughness);
+        colorAccumulative += ProcessSpotLight(light.spots[i], normal, viewDir, colorDiffuse.rgb, colorSpecular.rgb, roughness);
     }
 
     // Emission
-    colorAccumulative += GetEmissive(emissiveMap, uv, hasEmissiveMap).rgb;
+    colorAccumulative += GetEmissive(tiledUV).rgb;
 
     vec3 ldr = colorAccumulative.rgb / (colorAccumulative.rgb + vec3(1.0)); // reinhard tone mapping
     ldr = pow(ldr, vec3(1/2.2)); // gamma correction

--- a/Project/Source/Resources/ResourceMaterial.cpp
+++ b/Project/Source/Resources/ResourceMaterial.cpp
@@ -93,6 +93,8 @@ void ResourceMaterial::Unload() {
 	App->resources->DecreaseReferenceCount(specularMapId);
 	App->resources->DecreaseReferenceCount(metallicMapId);
 	App->resources->DecreaseReferenceCount(normalMapId);
+	App->resources->DecreaseReferenceCount(emissiveMapId);
+	App->resources->DecreaseReferenceCount(ambientOcclusionMapId);
 }
 
 void ResourceMaterial::SaveToFile(const char* filePath) {
@@ -177,146 +179,159 @@ void ResourceMaterial::OnEditorUpdate() {
 			}
 		}
 		ImGui::EndCombo();
-		ImGui::Text("");
-	}
-
-	//Diffuse
-	ImGui::TextColored(App->editor->titleColor, "Albedo");
-	ImGui::ColorEdit4("Diffuse Color##color_d", diffuseColor.ptr(), ImGuiColorEditFlags_NoInputs);
-	ImGui::ResourceSlot<ResourceTexture>("Diffuse Texture", &diffuseMapId);
-	if (ImGui::Button("Remove texture map##diffuse")) {
-		if (diffuseMapId != 0) {
-			App->resources->DecreaseReferenceCount(diffuseMapId);
-			diffuseMapId = 0;
-		}
-	}
-
-	if (shaderType == MaterialShader::PHONG) {
-		// Specular Options
-		ImGui::TextColored(App->editor->titleColor, "Specular");
-		if (specularMapId == 0) {
-			ImGui::ColorEdit4("Specular Color##color_s", specularColor.ptr(), ImGuiColorEditFlags_NoInputs);
-		}
-		ImGui::ResourceSlot<ResourceTexture>("Specular Texture", &specularMapId);
-		if (ImGui::Button("Remove texture map##specular")) {
-			if (specularMapId != 0) {
-				App->resources->DecreaseReferenceCount(specularMapId);
-				specularMapId = 0;
-			}
-		}
-
-		// Shininess Options
-		ImGui::TextColored(App->editor->titleColor, "Shininess");
-		const char* shininessItems[] = {"Shininess Value", "Shininess Alpha"};
-		const char* shininessItemCurrent = shininessItems[hasSmoothnessInAlphaChannel];
-		if (ImGui::BeginCombo("##shininess", shininessItemCurrent)) {
-			for (int n = 0; n < IM_ARRAYSIZE(shininessItems); ++n) {
-				bool isSelected = (shininessItemCurrent == shininessItems[n]);
-				if (ImGui::Selectable(shininessItems[n], isSelected)) {
-					hasSmoothnessInAlphaChannel = n ? 1 : 0;
-				}
-				if (isSelected) {
-					ImGui::SetItemDefaultFocus();
-				}
-			}
-			ImGui::EndCombo();
-		}
-
-		if (!hasSmoothnessInAlphaChannel) {
-			std::string id_s("##shininess_");
-			ImGui::PushID(id_s.c_str());
-			ImGui::DragFloat(id_s.c_str(), &smoothness, App->editor->dragSpeed1f, 0, 1000);
-			ImGui::PopID();
-		}
-
-	} else {
-		if (shaderType == MaterialShader::STANDARD_SPECULAR) {
-			// Specular Options
-			ImGui::TextColored(App->editor->titleColor, "Specular");
-			if (specularMapId == 0) {
-				ImGui::ColorEdit4("Specular Color##color_s", specularColor.ptr(), ImGuiColorEditFlags_NoInputs);
-			}
-			ImGui::ResourceSlot<ResourceTexture>("Specular Texture", &specularMapId);
-			if (ImGui::Button("Remove texture map##specular")) {
-				if (specularMapId != 0) {
-					App->resources->DecreaseReferenceCount(specularMapId);
-					specularMapId = 0;
-				}
-			}
-
-		} else if (shaderType == MaterialShader::STANDARD) {
-			// Metallic Options
-			ImGui::TextColored(App->editor->titleColor, "Metalness");
-			if (metallicMapId == 0) {
-				ImGui::SliderFloat("##metalness", &metallic, 0.0, 1.0);
-			}
-			ImGui::ResourceSlot<ResourceTexture>("Metallic Texture", &metallicMapId);
-			if (ImGui::Button("Remove texture map##metallic")) {
-				if (metallicMapId != 0) {
-					App->resources->DecreaseReferenceCount(metallicMapId);
-					metallicMapId = 0;
-				}
-			}
-		}
-
-		// Emissive Options
-		ImGui::TextColored(App->editor->titleColor, "Emissive Mapping");
-		ImGui::ResourceSlot<ResourceTexture>("Emissive Texture", &emissiveMapId);
-		if (ImGui::Button("Remove texture map##emissive")) {
-			if (emissiveMapId != 0) {
-				App->resources->DecreaseReferenceCount(emissiveMapId);
-				emissiveMapId = 0;
-			}
-		}
-
-		// Ambient Occlusion Options
-		ImGui::TextColored(App->editor->titleColor, "Ambient Occlusion Mapping");
-		ImGui::ResourceSlot<ResourceTexture>("Ambient Occlusion Texture", &ambientOcclusionMapId);
-		if (ImGui::Button("Remove texture map##ambientOcclusion")) {
-			if (ambientOcclusionMapId != 0) {
-				App->resources->DecreaseReferenceCount(ambientOcclusionMapId);
-				ambientOcclusionMapId = 0;
-			}
-		}
-
-		// Smoothness Options
-		ImGui::TextColored(App->editor->titleColor, "Smoothness");
-		ImGui::Text("Smoothness");
-
-		const char* smoothnessItems[] = {"Diffuse Alpha", "Specular Alpha"};
-		const char* smoothnessItemCurrent = smoothnessItems[hasSmoothnessInAlphaChannel];
-		if (ImGui::BeginCombo("##smoothness", smoothnessItemCurrent)) {
-			for (int n = 0; n < IM_ARRAYSIZE(smoothnessItems); ++n) {
-				bool isSelected = (smoothnessItemCurrent == smoothnessItems[n]);
-				if (ImGui::Selectable(smoothnessItems[n], isSelected)) {
-					hasSmoothnessInAlphaChannel = n;
-				}
-				if (isSelected) {
-					ImGui::SetItemDefaultFocus();
-				}
-			}
-			ImGui::EndCombo();
-		}
-		ImGui::SliderFloat("##smooth_", &smoothness, 0.0, 1.0);
-	}
-	
-
-	// Normal Options
-	ImGui::TextColored(App->editor->titleColor, "Normal Mapping");
-	ImGui::ResourceSlot<ResourceTexture>("Normal Texture", &normalMapId);
-	if (ImGui::Button("Remove texture map##normal")) {
-		if (normalMapId != 0) {
-			App->resources->DecreaseReferenceCount(normalMapId);
-			normalMapId = 0;
-		}
-	}
-	if (normalMapId != 0) {
-		ImGui::SliderFloat("##strength", &normalStrength, 0.0, 10.0);
 	}
 
 	ImGui::NewLine();
 
-	// Tiling Settingsextension
+	//Diffuse
+	ImGui::BeginColumns("##diffuse_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+	{
+		ImGui::ResourceSlot<ResourceTexture>("Diffuse Map", &diffuseMapId);
+	}
+	ImGui::NextColumn();
+	{
+		ImGui::NewLine();
+		ImGui::ColorEdit4("Color##color_d", diffuseColor.ptr(), ImGuiColorEditFlags_NoInputs);
+	}
+	ImGui::EndColumns();
+	ImGui::NewLine();
+
+	if (shaderType == MaterialShader::PHONG) {
+		// Specular Options
+		ImGui::BeginColumns("##specular_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+		{
+			ImGui::ResourceSlot<ResourceTexture>("Specular Map", &specularMapId);
+		}
+		ImGui::NextColumn();
+		{
+			ImGui::NewLine();
+			if (specularMapId == 0) {
+				ImGui::ColorEdit4("Color##color_s", specularColor.ptr(), ImGuiColorEditFlags_NoInputs);
+			}
+		}
+		ImGui::EndColumns();
+
+		// Shininess Options
+		ImGui::Text("Shininess");
+		ImGui::BeginColumns("##shininess_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+		{
+			const char* shininessItems[] = {"Shininess Value", "Shininess Alpha"};
+			const char* shininessItemCurrent = shininessItems[hasSmoothnessInAlphaChannel];
+			if (ImGui::BeginCombo("##shininess", shininessItemCurrent)) {
+				for (int n = 0; n < IM_ARRAYSIZE(shininessItems); ++n) {
+					bool isSelected = (shininessItemCurrent == shininessItems[n]);
+					if (ImGui::Selectable(shininessItems[n], isSelected)) {
+						hasSmoothnessInAlphaChannel = n ? 1 : 0;
+					}
+					if (isSelected) {
+						ImGui::SetItemDefaultFocus();
+					}
+				}
+				ImGui::EndCombo();
+			}
+		}
+		ImGui::NextColumn();
+		{
+			if (!hasSmoothnessInAlphaChannel) {
+				std::string id_s("##shininess_");
+				ImGui::PushID(id_s.c_str());
+				ImGui::DragFloat(id_s.c_str(), &smoothness, App->editor->dragSpeed1f, 0, 1000);
+				ImGui::PopID();
+			}
+		}
+		ImGui::EndColumns();
+		ImGui::NewLine();
+
+	} else {
+		const char* smoothnessItems[] = {"Diffuse Alpha", "Specular Alpha"};
+
+		if (shaderType == MaterialShader::STANDARD_SPECULAR) {
+			// Specular Options
+			ImGui::BeginColumns("##specular_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+			{
+				ImGui::ResourceSlot<ResourceTexture>("Specular Map", &specularMapId);
+			}
+			ImGui::NextColumn();
+			{
+				ImGui::NewLine();
+				if (specularMapId == 0) {
+					ImGui::ColorEdit4("Color##color_s", specularColor.ptr(), ImGuiColorEditFlags_NoInputs);
+				}
+			}
+			ImGui::EndColumns();
+
+		} else if (shaderType == MaterialShader::STANDARD) {
+			// Metallic Options
+			ImGui::BeginColumns("##metallic_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+			{
+				ImGui::ResourceSlot<ResourceTexture>("Metallic Map", &metallicMapId);
+			}
+			ImGui::NextColumn();
+			{
+				ImGui::NewLine();
+				if (metallicMapId == 0) {
+					ImGui::SliderFloat("##metalness", &metallic, 0.0, 1.0);
+				}
+			}
+			ImGui::EndColumns();
+
+			smoothnessItems[1] = "Metallic Alpha";
+		}
+
+		// Smoothness Options
+		//ImGui::TextColored(App->editor->titleColor, "Smoothness");
+		ImGui::Text("Smoothness");
+		ImGui::BeginColumns("##smoothness_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+		{
+			const char* smoothnessItemCurrent = smoothnessItems[hasSmoothnessInAlphaChannel];
+			if (ImGui::BeginCombo("##smoothness", smoothnessItemCurrent)) {
+				for (int n = 0; n < IM_ARRAYSIZE(smoothnessItems); ++n) {
+					bool isSelected = (smoothnessItemCurrent == smoothnessItems[n]);
+					if (ImGui::Selectable(smoothnessItems[n], isSelected)) {
+						hasSmoothnessInAlphaChannel = n;
+					}
+					if (isSelected) {
+						ImGui::SetItemDefaultFocus();
+					}
+				}
+				ImGui::EndCombo();
+			}
+		}
+		ImGui::NextColumn();
+		{
+			ImGui::SliderFloat("##smooth_", &smoothness, 0.0, 1.0);
+		}
+		ImGui::EndColumns();
+		ImGui::NewLine();
+	}
+
+	// Normal Options
+	ImGui::BeginColumns("##normal_material", 2, ImGuiColumnsFlags_NoResize | ImGuiColumnsFlags_NoBorder);
+	{
+		ImGui::ResourceSlot<ResourceTexture>("Normal Map", &normalMapId);
+	}
+	ImGui::NextColumn();
+	{
+		ImGui::NewLine();
+		if (normalMapId != 0) {
+			ImGui::SliderFloat("##strength", &normalStrength, 0.0, 10.0);
+		}
+	}
+	ImGui::EndColumns();
+	ImGui::NewLine();
+
+	// Ambient Occlusion Options
+	ImGui::ResourceSlot<ResourceTexture>("Occlusion Map", &ambientOcclusionMapId);
+
+	ImGui::NewLine();
+
+	// Emissive Options
+	ImGui::ResourceSlot<ResourceTexture>("Emissive Map", &emissiveMapId);
+
+	ImGui::NewLine();
+	ImGui::NewLine();
+
+	// Tiling Options
 	ImGui::DragFloat2("Tiling", tiling.ptr(), App->editor->dragSpeed1f, 1, inf);
 	ImGui::DragFloat2("Offset", offset.ptr(), App->editor->dragSpeed3f, -inf, inf);
 }

--- a/Project/Source/Utils/ImGuiUtils.h
+++ b/Project/Source/Utils/ImGuiUtils.h
@@ -7,6 +7,7 @@
 
 #include "imgui.h"
 #include "GL/glew.h"
+#include "IconsFontAwesome5.h"
 #include <functional>
 
 namespace ImGui {
@@ -66,8 +67,7 @@ inline void ImGui::ResourceSlot(const char* label, UID* target, std::function<vo
 
 template<>
 inline void ImGui::ResourceSlot<ResourceTexture>(const char* label, UID* target, std::function<void()> changeCallBack) {
-	ImGui::Text(label);
-	ImGui::BeginChildFrame(ImGui::GetID(target), ImVec2(200, 200));
+	ImGui::BeginChildFrame(ImGui::GetID(target), ImVec2(32, 32));
 	ResourceTexture* texture = App->resources->GetResource<ResourceTexture>(*target);
 	if (texture) {
 		ImTextureID texid = (ImTextureID) texture->glTexture;
@@ -89,22 +89,17 @@ inline void ImGui::ResourceSlot<ResourceTexture>(const char* label, UID* target,
 		ImGui::EndDragDropTarget();
 	}
 
+	ImGui::SameLine();
+	ImGui::Text(label);
+
+	std::string removeButton = std::string(ICON_FA_TIMES "##") + label;
+	if (ImGui::Button(removeButton.c_str())) {
+		if (*target != 0) {
+			App->resources->DecreaseReferenceCount(*target);
+			*target = 0;
+		}
+	}
+	ImGui::SameLine();
 	std::string resourceIdLabel = std::string("Id: ") + std::to_string(*target);
 	ImGui::Text(resourceIdLabel.c_str());
-
-	std::string resourceName = "None";
-	if (texture != nullptr) {
-		resourceName = texture->GetName();
-	}
-
-	std::string resourceNameLabel = std::string("Name: ") + resourceName;
-	ImGui::Text(resourceNameLabel.c_str());
-
-	if (texture) {
-		int width;
-		int height;
-		glGetTextureLevelParameteriv(texture->glTexture, 0, GL_TEXTURE_WIDTH, &width);
-		glGetTextureLevelParameteriv(texture->glTexture, 0, GL_TEXTURE_HEIGHT, &height);
-		ImGui::TextWrapped("Size: %d x %d", width, height);
-	}
 }


### PR DESCRIPTION
- [Hotfix] Add Tiled UVs to new Maps
- *Reorganize ResourceMaterial UI
- Clean shaders code

*The idea of adding the texture miniature is to have feedback that something is attached, not to show a big texture. It should be shown in the Resource Texture UI. Now it's so difficult to understand how the materials work and could be a problem when we operate with them in the game development. I put again the format from before, that's simpler. 

![202f78f42b50963113db23feb267f874](https://user-images.githubusercontent.com/48628366/119243896-53fe4680-bb6b-11eb-9f4f-922f1feaa3ae.gif)

VS

![newMaterial](https://user-images.githubusercontent.com/48628366/119243900-5bbdeb00-bb6b-11eb-99d3-8331a7a71686.png)

I keep the ID for now since I think is useful to check discrepancies with meta files (I would remove it). I will add the big texture with its information in the Resource Texture in another PR.

If you think any change is useless, please tell me and we can discuss it.
 