### PR TITLE
ComponentAgent Fix

### DIFF
--- a/Project/Source/Components/ComponentAgent.cpp
+++ b/Project/Source/Components/ComponentAgent.cpp
@@ -36,7 +36,13 @@ void ComponentAgent::SetMoveTarget(float3 newTargetPosition, bool usePathfinding
 		// Request velocity
 		const dtCrowdAgent* ag = crowd->getAgent(agentId);
 		if (ag && ag->active) {
-			float3 vel = (newTargetPosition - float3(ag->npos)).Normalized() * maxSpeed;
+			float3 targetResultPosition = (newTargetPosition - float3(ag->npos));
+			if (targetResultPosition.Equals(float3::zero)) {
+				targetResultPosition = float3::zero;
+			} else {
+				targetResultPosition.Normalize();
+			}
+			float3 vel = targetResultPosition * maxSpeed;
 			crowd->requestMoveVelocity(agentId, vel.ptr());
 		}
 	}

--- a/Project/Source/Components/ComponentAgent.cpp
+++ b/Project/Source/Components/ComponentAgent.cpp
@@ -37,9 +37,7 @@ void ComponentAgent::SetMoveTarget(float3 newTargetPosition, bool usePathfinding
 		const dtCrowdAgent* ag = crowd->getAgent(agentId);
 		if (ag && ag->active) {
 			float3 targetResultPosition = (newTargetPosition - float3(ag->npos));
-			if (targetResultPosition.Equals(float3::zero)) {
-				targetResultPosition = float3::zero;
-			} else {
+			if (!targetResultPosition.Equals(float3::zero)) {
 				targetResultPosition.Normalize();
 			}
 			float3 vel = targetResultPosition * maxSpeed;


### PR DESCRIPTION
When the Player is standing IDLE, and Gameplay sets the position to itself, it will automatically go to (1*moveSpeed, 0, 0) due to the normalization of newPosition - agent.pos, which returns (1, 0, 0) when should be (0, 0, 0)