### PR TITLE
Feature: Update Component Slider to works methods in scripts

### DIFF
--- a/Project/Source/Components/UI/ComponentSlider.cpp
+++ b/Project/Source/Components/UI/ComponentSlider.cpp
@@ -285,6 +285,12 @@ void ComponentSlider::ModifyValue(float mulitplier) {
 	}
 }
 
+void ComponentSlider::ChangeNormalizedValue(float normalizedValue) {
+	normalizedValue = normalizedValue;
+	currentValue = (maxValue - minValue) * normalizedValue;
+}
+
+
 float4 ComponentSlider::GetTintColor() const {
 	if (!IsActive()) return App->userInterface->GetErrorColor();
 

--- a/Project/Source/Components/UI/ComponentSlider.cpp
+++ b/Project/Source/Components/UI/ComponentSlider.cpp
@@ -285,8 +285,8 @@ void ComponentSlider::ModifyValue(float mulitplier) {
 	}
 }
 
-void ComponentSlider::ChangeNormalizedValue(float normalizedValue) {
-	normalizedValue = normalizedValue;
+void ComponentSlider::ChangeNormalizedValue(float normalizedValue_) {
+	normalizedValue = normalizedValue_;
 	currentValue = (maxValue - minValue) * normalizedValue;
 }
 

--- a/Project/Source/Components/UI/ComponentSlider.h
+++ b/Project/Source/Components/UI/ComponentSlider.h
@@ -26,7 +26,7 @@ public:
 	void OnClicked() override;
 	void OnClickedInternal() override;
 
-	void OnValueChanged(bool innerCall = false);
+	TESSERACT_ENGINE_API void OnValueChanged(bool innerCall = false);
 	void OnSliderDragged();
 
 	void Save(JsonValue jComponent) const override; // Serializes the component
@@ -47,7 +47,7 @@ public:
 	TESSERACT_ENGINE_API float GetNormalizedValue() const;
 	void ModifyValue(float multiplier);
 
-	TESSERACT_ENGINE_API void ChangeNormalizedValue(float normalizedValue); // IMPORTANT!!! Right now this method its used in Gameplay
+	TESSERACT_ENGINE_API void ChangeNormalizedValue(float normalizedValue); // IMPORTANT!!! Right now this method its only used in Gameplay
 
 public:
 	bool handleStopsOnEdge = false;

--- a/Project/Source/Components/UI/ComponentSlider.h
+++ b/Project/Source/Components/UI/ComponentSlider.h
@@ -47,7 +47,7 @@ public:
 	TESSERACT_ENGINE_API float GetNormalizedValue() const;
 	void ModifyValue(float multiplier);
 
-	TESSERACT_ENGINE_API void ChangeNormalizedValue(float normalizedValue); // IMPORTANT!!! Right now this method its only used in Gameplay
+	TESSERACT_ENGINE_API void ChangeNormalizedValue(float normalizedValue_); // IMPORTANT!!! Right now this method its only used in Gameplay
 
 public:
 	bool handleStopsOnEdge = false;

--- a/Project/Source/Components/UI/ComponentSlider.h
+++ b/Project/Source/Components/UI/ComponentSlider.h
@@ -47,6 +47,8 @@ public:
 	TESSERACT_ENGINE_API float GetNormalizedValue() const;
 	void ModifyValue(float multiplier);
 
+	TESSERACT_ENGINE_API void ChangeNormalizedValue(float normalizedValue); // IMPORTANT!!! Right now this method its used in Gameplay
+
 public:
 	bool handleStopsOnEdge = false;
 	bool beingHandled = false;
@@ -67,7 +69,7 @@ private:
 
 	float2 newPosition = float2(0, 0); // Click position inside the slider
 
-	float sliderSensitivity = 100.0f;							//Speed at which the slider's value will increase via keyboard/game controller input
+	float sliderSensitivity = 100.0f;							// Speed at which the slider's value will increase via keyboard/game controller input
 	bool clicked = false;										// Clicked state
 	float4 colorClicked = float4(0.64f, 0.64f, 0.64f, 1.f);		// The color when the button is clicked
 	float4 colorManualInput = float4(0.24f, 0.24f, 0.24f, 1.f); // The color when the button is clicked


### PR DESCRIPTION
I update two methods in the `ComponentSlider.cpp/h` to use them in a script that it will work as a Game Manager in Penteract, between scenes.

Its use will be to control the volume during the game right now...in the future we can put variable that we need during all the game's life, like the points or something like that.

**NOTE: GameManager will be introduced in next delivery (Alpha 1), so there is no rush to accept this PR.**