### PR TITLE
Fixed bug

### DIFF
--- a/Project/Source/GameplaySystems.cpp
+++ b/Project/Source/GameplaySystems.cpp
@@ -233,22 +233,17 @@ bool Input::GetKeyCode(KEYCODE keycode) {
 
 bool Input::GetControllerButtonDown(SDL_GameControllerButton button, int playerID) {
 	PlayerController* player = App->input->GetPlayerController(playerID);
-	return player ? false : player->gameControllerButtons[button] == KS_DOWN;
+	return player ? player->gameControllerButtons[button] == KS_DOWN : false;
 }
 
 bool Input::GetControllerButtonUp(SDL_GameControllerButton button, int playerID) {
 	PlayerController* player = App->input->GetPlayerController(playerID);
-	return player ? false : player->gameControllerButtons[button] == KS_UP;
-}
-
-bool Input::GetControllerButtonRepeat(SDL_GameControllerButton button, int playerID) {
-	PlayerController* player = App->input->GetPlayerController(playerID);
-	return player ? false : player->gameControllerButtons[button] == KS_REPEAT;
+	return player ? player->gameControllerButtons[button] == KS_UP : false;
 }
 
 bool Input::GetControllerButton(SDL_GameControllerButton button, int playerID) {
 	PlayerController* player = App->input->GetPlayerController(playerID);
-	return player ? false : player->gameControllerButtons[button];
+	return player ? player->gameControllerButtons[button] == KS_REPEAT : false;
 }
 
 float Input::GetControllerAxisValue(SDL_GameControllerAxis axis, int playerID) {

--- a/Project/Source/GameplaySystems.h
+++ b/Project/Source/GameplaySystems.h
@@ -444,7 +444,6 @@ namespace Input {
 	//For these methods, playerID does mean the array index
 	TESSERACT_ENGINE_API bool GetControllerButtonDown(SDL_GameControllerButton button, int playerID);
 	TESSERACT_ENGINE_API bool GetControllerButtonUp(SDL_GameControllerButton button, int playerID);
-	TESSERACT_ENGINE_API bool GetControllerButtonRepeat(SDL_GameControllerButton button, int playerID);
 	TESSERACT_ENGINE_API bool GetControllerButton(SDL_GameControllerButton button, int playerID);
 	TESSERACT_ENGINE_API float GetControllerAxisValue(SDL_GameControllerAxis axis, int playerID);
 	TESSERACT_ENGINE_API bool IsGamepadConnected(int playerID);


### PR DESCRIPTION
The Gameplay system methods to get button states generated a crash if used without a connected gamepad, and with a connected gamepad always returned false.