### PR TITLE
Hotfix/cu nkbkg9 render bugs

### DIFF
--- a/Project/Source/GameplaySystems.cpp
+++ b/Project/Source/GameplaySystems.cpp
@@ -373,6 +373,14 @@ float2 Screen::GetResolution() {
 	return float2(static_cast<float>(App->window->GetWidth()), static_cast<float>(App->window->GetHeight()));
 }
 
+const bool Screen::IsVSyncActive() {
+	return App->time->vsync;
+}
+
+void Screen::SetVSync(bool value) {
+	App->time->SetVSync(value);
+}
+
 void Screen::SetMSAAActive(bool value) {
 	App->renderer->msaaActive = value;
 	App->renderer->UpdateFramebuffers();

--- a/Project/Source/GameplaySystems.h
+++ b/Project/Source/GameplaySystems.h
@@ -478,6 +478,8 @@ namespace Screen {
 	TESSERACT_ENGINE_API int GetHeight();
 	TESSERACT_ENGINE_API float GetBrightness();
 	TESSERACT_ENGINE_API float2 GetResolution();
+	TESSERACT_ENGINE_API const bool IsVSyncActive();
+	TESSERACT_ENGINE_API void SetVSync(bool value);
 
 	TESSERACT_ENGINE_API void SetMSAAActive(bool value);
 	TESSERACT_ENGINE_API void SetMSAAType(MSAA_SAMPLES_TYPE value);

--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -642,12 +642,10 @@ UpdateStatus ModuleRender::Update() {
 UpdateStatus ModuleRender::PostUpdate() {
 	BROFILER_CATEGORY("ModuleRender - PostUpdate", Profiler::Color::Green)
 
-#if !GAME
 	if (viewportUpdated) {
 		UpdateFramebuffers();
 		viewportUpdated = false;
 	}
-#endif
 
 	SDL_GL_SwapWindow(App->window->window);
 

--- a/Project/Source/Modules/ModuleScene.cpp
+++ b/Project/Source/Modules/ModuleScene.cpp
@@ -102,6 +102,7 @@ bool ModuleScene::Start() {
 	}
 
 	App->time->SetVSync(true);
+	App->time->limitFramerate = false;
 #else
 	CreateEmptyScene();
 #endif

--- a/Project/Source/Modules/ModuleScene.cpp
+++ b/Project/Source/Modules/ModuleScene.cpp
@@ -100,8 +100,8 @@ bool ModuleScene::Start() {
 	if (App->scene->scene->root == nullptr) {
 		App->scene->CreateEmptyScene();
 	}
-	App->renderer->SetVSync(false);
-	App->time->limitFramerate = false;
+
+	App->time->SetVSync(true);
 #else
 	CreateEmptyScene();
 #endif

--- a/Project/Source/Modules/ModuleTime.cpp
+++ b/Project/Source/Modules/ModuleTime.cpp
@@ -104,7 +104,6 @@ UpdateStatus ModuleTime::ExitGame() {
 
 void ModuleTime::SetVSync(bool value) {
 	vsync = value;
-	limitFramerate = value;
 	App->renderer->SetVSync(value);
 }
 

--- a/Project/Source/Modules/ModuleTime.cpp
+++ b/Project/Source/Modules/ModuleTime.cpp
@@ -9,6 +9,7 @@
 #include "Modules/ModuleFiles.h"
 #include "Modules/ModuleEvents.h"
 #include "Modules/ModuleAudio.h"
+#include "Modules/ModuleRender.h"
 #include "Scene.h"
 #include "Modules/ModulePhysics.h"
 #include "SDL_timer.h"
@@ -99,6 +100,12 @@ void ModuleTime::WaitForEndOfFrame() {
 
 UpdateStatus ModuleTime::ExitGame() {
 	return UpdateStatus::STOP;
+}
+
+void ModuleTime::SetVSync(bool value) {
+	vsync = value;
+	limitFramerate = value;
+	App->renderer->SetVSync(value);
 }
 
 bool ModuleTime::HasGameStarted() const {

--- a/Project/Source/Modules/ModuleTime.h
+++ b/Project/Source/Modules/ModuleTime.h
@@ -42,6 +42,7 @@ public:
 	TESSERACT_ENGINE_API void ResumeGame();
 	void StepGame();
 	UpdateStatus ExitGame();
+	void SetVSync(bool value);
 
 public:
 	int maxFps = 60;			// Maximum FPS when the framerate is limited.

--- a/Project/Source/Modules/ModuleWindow.cpp
+++ b/Project/Source/Modules/ModuleWindow.cpp
@@ -47,6 +47,9 @@ bool ModuleWindow::Init() {
 		SDL_DisplayMode displayMode;
 		SDL_GetDisplayMode(SDL_GetWindowDisplayIndex(window), i, &displayMode);
 		displayModes.push_back(displayMode);
+		if (desktopDisplayMode.w == displayMode.w && desktopDisplayMode.h == displayMode.h && desktopDisplayMode.refresh_rate == displayMode.refresh_rate) {
+			currentDisplayMode = i;
+		}
 	}
 
 #if GAME


### PR DESCRIPTION
- UpdateFramebuffers isn't correctly called in Game causing wrong rendering when changing resolution. -> Now correctly changes rendering resolution.
- Initial resolution isn't the recommended resolution. -> Now the recommended resolution is applied.
- VSync is disabled. -> Now VSync is set to true by default and can be modified by Gameplay.