### PR TITLE
Soft particles

### DIFF
--- a/Game/Assets/Shaders/billboard.shader
+++ b/Game/Assets/Shaders/billboard.shader
@@ -9,7 +9,6 @@ uniform mat4 model;
 
 out vec2 uv0;
 
-
 void main()
 {
 	gl_Position = proj*view*model*vec4(vertexPosition.xyz , 1.0);
@@ -20,47 +19,54 @@ void main()
 
 in vec2 uv0;
 
+uniform float near;
+uniform float far;
+
+uniform sampler2D depths;
+
 uniform sampler2D diffuseMap;
 uniform int hasDiffuseMap;
 uniform vec4 inputColor;
 
-uniform float currentFrame; 
+uniform float currentFrame;
 uniform int Xtiles;
 uniform int Ytiles;
 
-uniform bool flipX;
-uniform bool flipY;
+uniform int flipX;
+uniform int flipY;
 
-float X;
-float Y;
-float u;
-float v;
+uniform int isSoft;
+
 out vec4 outColor;
+
+float LinearizeDepth(float depth) 
+{
+    return (far * near) / (far - depth * (far - near));	
+}
 
 void main()
 {	
-	u = uv0.x;
-	v = uv0.y;
-	
-	if (flipX) 
-	{
-		u = 1 - uv0.x;
-	}
+	float u = flipX * (1 - uv0.x) + (1 - flipX) * uv0.x;
+	float v = flipY * (1 - uv0.y) + (1 - flipY) * uv0.y;
 
-	if (flipY) 
-	{
-		v = 1 - uv0.y;
-	}
-
-	X = trunc(mod(currentFrame, Xtiles));
-	Y = trunc(currentFrame/Xtiles);
-	Y = (Ytiles - 1) - Y ;
-	X = mix(X,X+1,u);
-	Y = mix(Y,Y+1,v);
+	float X = trunc(mod(currentFrame, Xtiles));
+	float Y = trunc(currentFrame / Xtiles);
+	Y = (Ytiles - 1) - Y;
+	X = mix(X, X + 1, u);
+	Y = mix(Y, Y + 1, v);
 	
-	u = X/Xtiles;
-	v = Y/Ytiles;
+	u = X / Xtiles;
+	v = Y / Ytiles;
 	
 	outColor = SRGBA(inputColor) * (hasDiffuseMap * SRGBA(texture2D(diffuseMap,  vec2(u, v))) + (1 - hasDiffuseMap));
+	
+	if (isSoft == 1) {
+		vec2 screenUV = gl_FragCoord.xy / vec2(textureSize(depths, 0));
+		float sceneDepth = LinearizeDepth(texture2D(depths, screenUV).r);
+		float fragDepth = LinearizeDepth(gl_FragCoord.z);
+		float depthDelta = sceneDepth - fragDepth;
+		float opacity = smoothstep(0.0, 1.0, depthDelta);
+		outColor.a *= opacity;
+	}
 }
 

--- a/Game/Assets/Shaders/billboard.shader
+++ b/Game/Assets/Shaders/billboard.shader
@@ -28,6 +28,8 @@ uniform sampler2D diffuseMap;
 uniform int hasDiffuseMap;
 uniform vec4 inputColor;
 
+uniform int transparent;
+
 uniform float currentFrame;
 uniform int Xtiles;
 uniform int Ytiles;
@@ -36,6 +38,7 @@ uniform int flipX;
 uniform int flipY;
 
 uniform int isSoft;
+uniform float softRange;
 
 out vec4 outColor;
 
@@ -65,8 +68,8 @@ void main()
 		float sceneDepth = LinearizeDepth(texture2D(depths, screenUV).r);
 		float fragDepth = LinearizeDepth(gl_FragCoord.z);
 		float depthDelta = sceneDepth - fragDepth;
-		float opacity = smoothstep(0.0, 1.0, depthDelta);
-		outColor.a *= opacity;
+		float opacity = smoothstep(0.0, 1.0, depthDelta / softRange);
+		outColor *= vec4(vec3((1 - transparent) * opacity + transparent), transparent * opacity + (1 - transparent));
 	}
 }
 

--- a/Game/Assets/Shaders/depthPrePass.shader
+++ b/Game/Assets/Shaders/depthPrePass.shader
@@ -43,6 +43,7 @@ in vec2 uv;
 
 uniform int samplesNumber;
 
+uniform sampler2DMS depths;
 uniform sampler2DMS positions;
 uniform sampler2DMS normals;
 
@@ -51,14 +52,15 @@ void main()
     ivec2 positionsSize = textureSize(positions);
     ivec2 vp = ivec2(vec2(positionsSize) * uv);
     int minIndex = 0;
-    float minDepth = texelFetch(positions, vp, 0).z;
+    float minDepth = texelFetch(depths, vp, 0).r;
     for (int i = 1; i < samplesNumber; ++i) {
-        float depth = texelFetch(positions, vp, i).z;
-        if (depth < minDepth) {
+        float sampleDepth = texelFetch(depths, vp, i).r;
+        if (sampleDepth < minDepth) {
             minIndex = i;
-            minDepth = depth;
+            minDepth = sampleDepth;
         }
     }
     position = texelFetch(positions, vp, minIndex);
     normal = texelFetch(normals, vp, minIndex);
+    gl_FragDepth = minDepth;
 }

--- a/Project/Source/Components/ComponentParticleSystem.cpp
+++ b/Project/Source/Components/ComponentParticleSystem.cpp
@@ -99,6 +99,7 @@
 #define JSON_TAG_PARTICLE_RENDER_ALIGNMENT "ParticleRenderAlignment"
 #define JSON_TAG_FLIP_TEXTURE "FlipTexture"
 #define JSON_TAG_IS_SOFT "IsSoft"
+#define JSON_TAG_SOFT_RANGE "SoftRange"
 
 // Collision
 #define JSON_TAG_HAS_COLLISION "HasCollision"
@@ -349,9 +350,10 @@ void ComponentParticleSystem::OnEditorUpdate() {
 		ImGui::Checkbox("Y", &flipTexture[1]);
 
 		ImGui::NewLine();
-		ImGui::Text("Spft: ");
+		ImGui::Text("Soft: ");
 		ImGui::SameLine();
 		ImGui::Checkbox("##soft", &isSoft);
+		ImGui::DragFloat("Softness Range", &softRange, App->editor->dragSpeed2f, 0.0f, inf);
 	}
 
 	// Collision
@@ -516,6 +518,7 @@ void ComponentParticleSystem::Load(JsonValue jComponent) {
 	flipTexture[0] = jFlip[0];
 	flipTexture[1] = jFlip[1];
 	isSoft = jComponent[JSON_TAG_IS_SOFT];
+	softRange = jComponent[JSON_TAG_SOFT_RANGE];
 
 	// Collision
 	collision = jComponent[JSON_TAG_HAS_COLLISION];
@@ -628,6 +631,7 @@ void ComponentParticleSystem::Save(JsonValue jComponent) const {
 	jFlip[0] = flipTexture[0];
 	jFlip[1] = flipTexture[1];
 	jComponent[JSON_TAG_IS_SOFT] = isSoft;
+	jComponent[JSON_TAG_SOFT_RANGE] = softRange;
 
 	// Collision
 	jComponent[JSON_TAG_HAS_COLLISION] = collision;
@@ -997,6 +1001,8 @@ void ComponentParticleSystem::Draw() {
 			glUniform1f(program->nearLocation, App->camera->GetNearPlane());
 			glUniform1f(program->farLocation, App->camera->GetFarPlane());
 
+			glUniform1i(program->transparentLocation, renderMode == ParticleRenderMode::TRANSPARENT ? 1 : 0);
+
 			glActiveTexture(GL_TEXTURE0);
 			glBindTexture(GL_TEXTURE_2D, App->renderer->depthsTexture);
 			glUniform1i(program->depthsLocation, 0);
@@ -1016,6 +1022,7 @@ void ComponentParticleSystem::Draw() {
 			glUniform1i(program->yFlipLocation, flipTexture[1] ? 1 : 0);
 
 			glUniform1i(program->isSoftLocation, isSoft ? 1 : 0);
+			glUniform1f(program->softRangeLocation, softRange);
 
 			//TODO: implement drawarrays
 			glDrawArrays(GL_TRIANGLES, 0, 6);

--- a/Project/Source/Components/ComponentParticleSystem.h
+++ b/Project/Source/Components/ComponentParticleSystem.h
@@ -323,6 +323,7 @@ private:
 	ParticleRenderAlignment renderAlignment = ParticleRenderAlignment::VIEW;
 	bool flipTexture[2] = {false, false};
 	bool isSoft = false;
+	float softRange = 1.0f;
 
 	// Collision
 	bool collision = false;

--- a/Project/Source/Components/ComponentParticleSystem.h
+++ b/Project/Source/Components/ComponentParticleSystem.h
@@ -231,6 +231,7 @@ public:
 	TESSERACT_ENGINE_API void SetRenderAlignment(ParticleRenderAlignment _renderAligment);
 	TESSERACT_ENGINE_API void SetFlipXTexture(bool _flipX);
 	TESSERACT_ENGINE_API void SetFlipYTexture(bool _flipY);
+	TESSERACT_ENGINE_API void SetIsSoft(bool _isSoft);
 
 	// Collision
 	TESSERACT_ENGINE_API void SetCollision(bool _collision);
@@ -321,6 +322,7 @@ private:
 	ParticleRenderMode renderMode = ParticleRenderMode::ADDITIVE;
 	ParticleRenderAlignment renderAlignment = ParticleRenderAlignment::VIEW;
 	bool flipTexture[2] = {false, false};
+	bool isSoft = false;
 
 	// Collision
 	bool collision = false;

--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -226,8 +226,10 @@ bool ModuleRender::Init() {
 
 	glGenTextures(1, &renderTexture);
 	glGenTextures(1, &outputTexture);
+	glGenTextures(1, &depthsMSTexture);
 	glGenTextures(1, &positionsMSTexture);
 	glGenTextures(1, &normalsMSTexture);
+	glGenTextures(1, &depthsTexture);
 	glGenTextures(1, &positionsTexture);
 	glGenTextures(1, &normalsTexture);
 	glGenTextures(1, &depthMapTexture);
@@ -235,8 +237,6 @@ bool ModuleRender::Init() {
 	glGenTextures(1, &auxBlurTexture);
 	glGenTextures(2, colorTextures);
 	glGenTextures(2, bloomBlurTextures);
-
-	glGenRenderbuffers(1, &depthBuffer);
 
 	glGenFramebuffers(1, &renderPassBuffer);
 	glGenFramebuffers(1, &depthPrepassBuffer);
@@ -345,12 +345,16 @@ void ModuleRender::ConvertDepthPrepassTextures() {
 	glUniform1i(convertProgram->samplesNumberLocation, msaaActive ? msaaSamplesNumber[static_cast<int>(msaaSampleType)] : msaaSampleSingle);
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, positionsMSTexture);
-	glUniform1i(convertProgram->positionsLocation, 0);
+	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, depthsMSTexture);
+	glUniform1i(convertProgram->depthsLocation, 0);
 
 	glActiveTexture(GL_TEXTURE1);
+	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, positionsMSTexture);
+	glUniform1i(convertProgram->positionsLocation, 1);
+
+	glActiveTexture(GL_TEXTURE2);
 	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, normalsMSTexture);
-	glUniform1i(convertProgram->normalsLocation, 1);
+	glUniform1i(convertProgram->normalsLocation, 2);
 
 	glDrawArrays(GL_TRIANGLES, 0, 3);
 }
@@ -531,8 +535,10 @@ UpdateStatus ModuleRender::Update() {
 	// Depth Prepass texture conversion
 	glBindFramebuffer(GL_FRAMEBUFFER, depthPrepassTextureConversionBuffer);
 	glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
-	glDisable(GL_DEPTH_TEST);
-	glClear(GL_COLOR_BUFFER_BIT);
+	glEnable(GL_DEPTH_TEST);
+	glDepthMask(GL_TRUE);
+	glDepthFunc(GL_ALWAYS);
+	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 	ConvertDepthPrepassTextures();
 
@@ -777,8 +783,10 @@ bool ModuleRender::CleanUp() {
 
 	glDeleteTextures(1, &renderTexture);
 	glDeleteTextures(1, &outputTexture);
+	glDeleteTextures(1, &depthsMSTexture);
 	glDeleteTextures(1, &positionsMSTexture);
 	glDeleteTextures(1, &normalsMSTexture);
+	glDeleteTextures(1, &depthsTexture);
 	glDeleteTextures(1, &positionsTexture);
 	glDeleteTextures(1, &normalsTexture);
 	glDeleteTextures(1, &depthMapTexture);
@@ -786,8 +794,6 @@ bool ModuleRender::CleanUp() {
 	glDeleteTextures(1, &auxBlurTexture);
 	glDeleteTextures(2, colorTextures);
 	glDeleteTextures(2, bloomBlurTextures);
-
-	glDeleteRenderbuffers(1, &depthBuffer);
 
 	glDeleteFramebuffers(1, &renderPassBuffer);
 	glDeleteFramebuffers(1, &depthPrepassBuffer);
@@ -823,14 +829,12 @@ void ModuleRender::ReceiveEvent(TesseractEvent& ev) {
 void ModuleRender::UpdateFramebuffers() {
 	unsigned msaaSamples = msaaActive ? msaaSamplesNumber[static_cast<int>(msaaSampleType)] : msaaSampleSingle;
 
-	// Depth buffer
-	glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
-	glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaaSamples, GL_DEPTH24_STENCIL8, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y));
-	glBindRenderbuffer(GL_RENDERBUFFER, 0);
-
 	// Depth prepass buffer
 	glBindFramebuffer(GL_FRAMEBUFFER, depthPrepassBuffer);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
+
+	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, depthsMSTexture);
+	glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, msaaSamples, GL_DEPTH24_STENCIL8, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y), GL_TRUE);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, depthsMSTexture, 0);
 
 	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, positionsMSTexture);
 	glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, msaaSamples, GL_RGB16F, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y), GL_TRUE);
@@ -840,11 +844,19 @@ void ModuleRender::UpdateFramebuffers() {
 	glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, msaaSamples, GL_RGB16F, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y), GL_TRUE);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D_MULTISAMPLE, normalsMSTexture, 0);
 
-	GLuint drawBuffers[] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
-	glDrawBuffers(2, drawBuffers);
+	GLuint drawBuffers2[] = {GL_COLOR_ATTACHMENT0, GL_COLOR_ATTACHMENT1};
+	glDrawBuffers(2, drawBuffers2);
 
 	// Depth prepass texture conversion buffer
 	glBindFramebuffer(GL_FRAMEBUFFER, depthPrepassTextureConversionBuffer);
+
+	glBindTexture(GL_TEXTURE_2D, depthsTexture);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y), 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, depthsTexture, 0);
 
 	glBindTexture(GL_TEXTURE_2D, positionsTexture);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB16F, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y), 0, GL_RGB, GL_FLOAT, NULL);
@@ -862,7 +874,7 @@ void ModuleRender::UpdateFramebuffers() {
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, normalsTexture, 0);
 
-	glDrawBuffers(2, drawBuffers);
+	glDrawBuffers(2, drawBuffers2);
 
 	// Shadow buffer
 	glBindFramebuffer(GL_FRAMEBUFFER, depthMapTextureBuffer);
@@ -913,7 +925,9 @@ void ModuleRender::UpdateFramebuffers() {
 
 	// Render buffer
 	glBindFramebuffer(GL_FRAMEBUFFER, renderPassBuffer);
-	glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
+
+	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, depthsMSTexture);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D_MULTISAMPLE, depthsMSTexture, 0);
 
 	glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, renderTexture);
 	glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, msaaSamples, GL_RGB16F, static_cast<int>(viewportSize.x), static_cast<int>(viewportSize.y), GL_TRUE);

--- a/Project/Source/Modules/ModuleRender.h
+++ b/Project/Source/Modules/ModuleRender.h
@@ -70,8 +70,10 @@ public:
 
 	unsigned renderTexture = 0;
 	unsigned outputTexture = 0;
+	unsigned depthsMSTexture = 0;
 	unsigned positionsMSTexture = 0;
 	unsigned normalsMSTexture = 0;
+	unsigned depthsTexture = 0;
 	unsigned positionsTexture = 0;
 	unsigned normalsTexture = 0;
 	unsigned depthMapTexture = 0;
@@ -79,8 +81,6 @@ public:
 	unsigned auxBlurTexture = 0;
 	unsigned colorTextures[2] = {0, 0}; // position 0: scene render texture; position 1: bloom texture to be blurred
 	unsigned bloomBlurTextures[2] = {0, 0};
-
-	unsigned depthBuffer = 0;
 
 	unsigned renderPassBuffer = 0;
 	unsigned depthPrepassBuffer = 0;

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -284,6 +284,8 @@ ProgramBillboard::ProgramBillboard(unsigned program_)
 	nearLocation = glGetUniformLocation(program, "near");
 	farLocation = glGetUniformLocation(program, "far");
 
+	transparentLocation = glGetUniformLocation(program, "transparent");
+
 	depthsLocation = glGetUniformLocation(program, "depths");
 
 	diffuseMapLocation = glGetUniformLocation(program, "diffuseMap");
@@ -295,7 +297,9 @@ ProgramBillboard::ProgramBillboard(unsigned program_)
 	yTilesLocation = glGetUniformLocation(program, "Ytiles");
 	xFlipLocation = glGetUniformLocation(program, "flipX");
 	yFlipLocation = glGetUniformLocation(program, "flipY");
+
 	isSoftLocation = glGetUniformLocation(program, "isSoft");
+	softRangeLocation = glGetUniformLocation(program, "softRange");
 }
 
 ProgramTrail::ProgramTrail(unsigned program_)

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -196,6 +196,7 @@ ProgramDepthPrepassConvertTextures::ProgramDepthPrepassConvertTextures(unsigned 
 	: Program(program_) {
 	samplesNumberLocation = glGetUniformLocation(program, "samplesNumber");
 
+	depthsLocation = glGetUniformLocation(program, "depths");
 	positionsLocation = glGetUniformLocation(program, "positions");
 	normalsLocation = glGetUniformLocation(program, "normals");
 }
@@ -280,6 +281,11 @@ ProgramBillboard::ProgramBillboard(unsigned program_)
 	viewLocation = glGetUniformLocation(program, "view");
 	projLocation = glGetUniformLocation(program, "proj");
 
+	nearLocation = glGetUniformLocation(program, "near");
+	farLocation = glGetUniformLocation(program, "far");
+
+	depthsLocation = glGetUniformLocation(program, "depths");
+
 	diffuseMapLocation = glGetUniformLocation(program, "diffuseMap");
 	hasDiffuseLocation = glGetUniformLocation(program, "hasDiffuseMap");
 	inputColorLocation = glGetUniformLocation(program, "inputColor");
@@ -289,6 +295,7 @@ ProgramBillboard::ProgramBillboard(unsigned program_)
 	yTilesLocation = glGetUniformLocation(program, "Ytiles");
 	xFlipLocation = glGetUniformLocation(program, "flipX");
 	yFlipLocation = glGetUniformLocation(program, "flipY");
+	isSoftLocation = glGetUniformLocation(program, "isSoft");
 }
 
 ProgramTrail::ProgramTrail(unsigned program_)

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -300,6 +300,8 @@ struct ProgramBillboard : Program {
 	int nearLocation = -1;
 	int farLocation = -1;
 
+	int transparentLocation = -1;
+
 	int depthsLocation = -1;
 
 	int inputColorLocation = -1;
@@ -311,7 +313,9 @@ struct ProgramBillboard : Program {
 	int yTilesLocation = -1;
 	int xFlipLocation = -1;
 	int yFlipLocation = -1;
+
 	int isSoftLocation = -1;
+	int softRangeLocation = -1;
 };
 struct ProgramTrail : Program {
 	ProgramTrail(unsigned program);

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -204,6 +204,7 @@ struct ProgramDepthPrepassConvertTextures : Program {
 
 	int samplesNumberLocation = -1;
 
+	int depthsLocation = -1;
 	int positionsLocation = -1;
 	int normalsLocation = -1;
 };
@@ -296,6 +297,11 @@ struct ProgramBillboard : Program {
 	int viewLocation = -1;
 	int projLocation = -1;
 
+	int nearLocation = -1;
+	int farLocation = -1;
+
+	int depthsLocation = -1;
+
 	int inputColorLocation = -1;
 	int hasDiffuseLocation = -1;
 	int diffuseMapLocation = -1;
@@ -305,6 +311,7 @@ struct ProgramBillboard : Program {
 	int yTilesLocation = -1;
 	int xFlipLocation = -1;
 	int yFlipLocation = -1;
+	int isSoftLocation = -1;
 };
 struct ProgramTrail : Program {
 	ProgramTrail(unsigned program);


### PR DESCRIPTION
This PR adds a new option on particle effects: Soft particles. Soft particles allow particles to fade when they are near the level geometry so that hard edges aren't visible.

Added options:
- Soft (true / false)
- Soft range (Distance to the geometry before turning fully opaque)

![image](https://imgur.com/M0gtJgP.gif)

