### PR TITLE
Improve light attenuation

### DIFF
--- a/Game/Assets/Materials/SpheresIBL/Sphere02.mat
+++ b/Game/Assets/Materials/SpheresIBL/Sphere02.mat
@@ -20,8 +20,9 @@
     "NormalMap": 0,
     "NormalStrength": 0.0,
     "EmissiveMap": 0,
+    "Emissive": 0.0,
     "AmbientOcclusionMap": 0,
-    "Smoothness": 0.25,
+    "Smoothness": 0.5,
     "HasSmoothnessInAlphaChannel": false,
     "Tiling": [
         1.0,

--- a/Game/Assets/Scenes/IBL.scene
+++ b/Game/Assets/Scenes/IBL.scene
@@ -7,7 +7,7 @@
     ],
     "QuadtreeMaxDepth": 4,
     "QuadtreeElementsPerNode": 200,
-    "GameCamera": 18291458259393081356,
+    "GameCamera": 71277050702357301,
     "AmbientLight": [
         0.25,
         0.25,
@@ -97,8 +97,9 @@
                             1.0
                         ],
                         "Intensity": 1.0,
-                        "Kl": 0.04500000178813934,
-                        "Kq": 0.007499999832361937,
+                        "Radius": 1.0,
+                        "UseCustomFalloff": false,
+                        "FalloffExponent": 0.0,
                         "InnerAngle": 0.2617993950843811,
                         "OuterAngle": 0.5235987901687622
                     }
@@ -171,13 +172,17 @@
                         "Id": 11840596377370928096,
                         "Active": true,
                         "Shader": 0,
-                        "Skybox": 17754930081670969392
+                        "Skybox": 17754930081670969392,
+                        "Strength": 1.0
                     },
                     {
                         "Type": "AudioListener",
                         "Id": 8215766938036622007,
                         "Active": true,
-                        "Gain": 1.0
+                        "Gain": 1.0,
+                        "ModelIndex": 0,
+                        "DistanceModel": 0,
+                        "Clamped": false
                     }
                 ],
                 "Children": null

--- a/Game/Assets/Shaders/fragmentPhong.shader
+++ b/Game/Assets/Shaders/fragmentPhong.shader
@@ -50,7 +50,9 @@ void main()
     // Point Light
     for (int i = 0; i < light.numPoints; i++) {
         float pointDistance = length(light.points[i].pos - fragPos);
-        float distAttenuation = 1.0 / (light.points[i].kc + light.points[i].kl * pointDistance + light.points[i].kq * pointDistance * pointDistance);
+        float falloffExponent = light.points[i].useCustomFalloff * light.points[i].falloffExponent + (1 - light.points[i].useCustomFalloff) * 4.0;
+        float distAttenuation = clamp(1.0 - pow(pointDistance / light.points[i].radius, falloffExponent), 0.0, 1.0);
+        distAttenuation = light.points[i].useCustomFalloff * distAttenuation + (1 - light.points[i].useCustomFalloff) * distAttenuation * distAttenuation / (pointDistance * pointDistance + 1.0);
 
         vec3 pointDir = normalize(fragPos - light.points[i].pos);
         float NL = max(dot(normal, -pointDir), 0.0);
@@ -68,8 +70,10 @@ void main()
     // Spot Light
     for (int i = 0; i < light.numSpots; i++) {
         float spotDistance = length(light.spots[i].pos - fragPos);
-        float distAttenuation = 1.0 / (light.spots[i].kc + light.spots[i].kl * spotDistance + light.spots[i].kq * spotDistance * spotDistance);
-
+        float falloffExponent = light.spots[i].useCustomFalloff * light.spots[i].falloffExponent + (1 - light.spots[i].useCustomFalloff) * 4.0;
+        float distAttenuation = clamp(1.0 - pow(spotDistance / light.spots[i].radius, falloffExponent), 0.0, 1.0);
+        distAttenuation = light.spots[i].useCustomFalloff * distAttenuation + (1 - light.spots[i].useCustomFalloff) * distAttenuation * distAttenuation / (spotDistance * spotDistance + 1.0);
+        
         vec3 spotDir = normalize(fragPos - light.spots[i].pos);
 
         vec3 aimDir = normalize(light.spots[i].direction);

--- a/Game/Assets/Shaders/fragmentStandard.shader
+++ b/Game/Assets/Shaders/fragmentStandard.shader
@@ -65,9 +65,9 @@ struct PointLight
 	vec3 pos;
 	vec3 color;
 	float intensity;
-	float kc;
-	float kl;
-	float kq;
+	float radius;
+	int useCustomFalloff;
+	float falloffExponent;
 };
 
 struct SpotLight
@@ -76,9 +76,9 @@ struct SpotLight
 	vec3 direction;
 	vec3 color;
 	float intensity;
-	float kc;
-	float kl;
-	float kq;
+	float radius;
+	int useCustomFalloff;
+	float falloffExponent;
 	float innerAngle;
 	float outerAngle;
 };
@@ -232,7 +232,9 @@ vec3 ProcessDirectionalLight(DirLight directional, vec3 fragNormal, vec3 viewDir
 vec3 ProcessPointLight(PointLight point, vec3 fragNormal, vec3 viewDir, vec3 Cd, vec3 F0, float roughness)
 {
 	float pointDistance = length(point.pos - fragPos);
-	float distAttenuation = 1.0 / (point.kc + point.kl * pointDistance + point.kq * pointDistance * pointDistance);
+	float falloffExponent = point.useCustomFalloff * point.falloffExponent + (1 - point.useCustomFalloff) * 4.0;
+	float distAttenuation = clamp(1.0 - pow(pointDistance / point.radius, falloffExponent), 0.0, 1.0);
+	distAttenuation = point.useCustomFalloff * distAttenuation + (1 - point.useCustomFalloff) * distAttenuation * distAttenuation / (pointDistance * pointDistance + 1.0);
 
 	vec3 pointDir = normalize(point.pos - fragPos);
 
@@ -253,7 +255,9 @@ vec3 ProcessPointLight(PointLight point, vec3 fragNormal, vec3 viewDir, vec3 Cd,
 vec3 ProcessSpotLight(SpotLight spot, vec3 fragNormal, vec3 viewDir, vec3 Cd, vec3 F0, float roughness)
 {
 	float spotDistance = length(spot.pos - fragPos);
-	float distAttenuation = 1.0 / (spot.kc + spot.kl * spotDistance + spot.kq * spotDistance * spotDistance);
+	float falloffExponent = spot.useCustomFalloff * spot.falloffExponent + (1 - spot.useCustomFalloff) * 4.0;
+	float distAttenuation = clamp(1.0 - pow(spotDistance / spot.radius, falloffExponent), 0.0, 1.0);
+	distAttenuation = spot.useCustomFalloff * distAttenuation + (1 - spot.useCustomFalloff) * distAttenuation * distAttenuation / (spotDistance * spotDistance + 1.0);
 
 	vec3 spotDir = normalize(spot.pos - fragPos);
 

--- a/Project/Source/Components/ComponentLight.cpp
+++ b/Project/Source/Components/ComponentLight.cpp
@@ -18,8 +18,9 @@
 #define JSON_TAG_LIGHT_TYPE "LightType"
 #define JSON_TAG_COLOR "Color"
 #define JSON_TAG_INTENSITY "Intensity"
-#define JSON_TAG_KL "Kl"
-#define JSON_TAG_KQ "Kq"
+#define JSON_TAG_RADIUS "Radius"
+#define JSON_TAG_USE_CUSTOM_FALLOFF "UseCustomFalloff"
+#define JSON_TAG_FALLOFF_EXPONENT "FalloffExponent"
 #define JSON_TAG_INNER_ANGLE "InnerAngle"
 #define JSON_TAG_OUTER_ANGLE "OuterAngle"
 
@@ -39,12 +40,10 @@ void ComponentLight::DrawGizmos() {
 			ComponentTransform* transform = GetOwner().GetComponent<ComponentTransform>();
 			dd::cone(pos, direction * 200, dd::colors::White, 1.0f, 1.0f);
 		} else {
-			float delta = kl * kl - 4 * (kc - 10) * kq;
-			float distance = Max(abs((-kl + sqrt(delta))) / (2 * kq), abs((-kl - sqrt(delta)) / (2 * kq)));
 			if (lightType == LightType::POINT) {
-				dd::sphere(pos, dd::colors::White, distance);
+				dd::sphere(pos, dd::colors::White, radius);
 			} else if (lightType == LightType::SPOT) {
-				dd::cone(pos, direction * distance, dd::colors::White, distance * tan(outerAngle), 0.0f);
+				dd::cone(pos, direction * radius, dd::colors::White, radius * tan(outerAngle), 0.0f);
 			}
 		}
 	}
@@ -91,15 +90,19 @@ void ComponentLight::OnEditorUpdate() {
 		ImGui::EndCombo();
 	}
 
-	if (lightType == LightType::DIRECTIONAL)
+	if (lightType == LightType::DIRECTIONAL) {
 		ImGui::InputFloat3("Direction", direction.ptr(), "%.3f", ImGuiInputTextFlags_ReadOnly);
+	}
 
 	ImGui::ColorEdit3("Color", color.ptr());
-	ImGui::DragFloat("Intensity", &intensity, App->editor->dragSpeed3f, 0.0f, inf);
+	ImGui::DragFloat("Intensity", &intensity, App->editor->dragSpeed1f, 0.0f, inf);
 
 	if (lightType == LightType::POINT || lightType == LightType::SPOT) {
-		ImGui::DragFloat("Linear Constant", &kl, App->editor->dragSpeed5f, 0.0f, 2.0f);
-		ImGui::DragFloat("Quadratic Constant", &kq, App->editor->dragSpeed5f, 0.0f, 2.0f);
+		ImGui::DragFloat("Radius", &radius, App->editor->dragSpeed1f, 0.0f, inf);
+		ImGui::Checkbox("Use Custom Falloff", &useCustomFalloff);
+		if (useCustomFalloff) {
+			ImGui::DragFloat("Falloff Exponent", &falloffExponent, App->editor->dragSpeed4f, 0.0f, inf);
+		}
 	}
 
 	if (lightType == LightType::SPOT) {
@@ -115,51 +118,33 @@ void ComponentLight::OnEditorUpdate() {
 }
 
 void ComponentLight::Save(JsonValue jComponent) const {
-	JsonValue jLightType = jComponent[JSON_TAG_LIGHT_TYPE];
-	jLightType = (int) lightType;
+	jComponent[JSON_TAG_LIGHT_TYPE] = (int) lightType;
 
 	JsonValue jColor = jComponent[JSON_TAG_COLOR];
 	jColor[0] = color.x;
 	jColor[1] = color.y;
 	jColor[2] = color.z;
 
-	JsonValue jIntensity = jComponent[JSON_TAG_INTENSITY];
-	jIntensity = intensity;
-
-	JsonValue jKl = jComponent[JSON_TAG_KL];
-	jKl = kl;
-
-	JsonValue jKq = jComponent[JSON_TAG_KQ];
-	jKq = kq;
-
-	JsonValue jInnerAngle = jComponent[JSON_TAG_INNER_ANGLE];
-	jInnerAngle = innerAngle;
-
-	JsonValue jOuterAngle = jComponent[JSON_TAG_OUTER_ANGLE];
-	jOuterAngle = outerAngle;
+	jComponent[JSON_TAG_INTENSITY] = intensity;
+	jComponent[JSON_TAG_RADIUS] = radius;
+	jComponent[JSON_TAG_USE_CUSTOM_FALLOFF] = useCustomFalloff;
+	jComponent[JSON_TAG_FALLOFF_EXPONENT] = falloffExponent;
+	jComponent[JSON_TAG_INNER_ANGLE] = innerAngle;
+	jComponent[JSON_TAG_OUTER_ANGLE] = outerAngle;
 }
 
 void ComponentLight::Load(JsonValue jComponent) {
-	JsonValue jLightType = jComponent[JSON_TAG_LIGHT_TYPE];
-	lightType = (LightType)(int) jLightType;
+	lightType = (LightType)(int) jComponent[JSON_TAG_LIGHT_TYPE];
 
 	JsonValue jColor = jComponent[JSON_TAG_COLOR];
 	color.Set(jColor[0], jColor[1], jColor[2]);
 
-	JsonValue jIntensity = jComponent[JSON_TAG_INTENSITY];
-	intensity = jIntensity;
-
-	JsonValue jKl = jComponent[JSON_TAG_KL];
-	kl = jKl;
-
-	JsonValue jKq = jComponent[JSON_TAG_KQ];
-	kq = jKq;
-
-	JsonValue jInnerAngle = jComponent[JSON_TAG_INNER_ANGLE];
-	innerAngle = jInnerAngle;
-
-	JsonValue jOuterAngle = jComponent[JSON_TAG_OUTER_ANGLE];
-	outerAngle = jOuterAngle;
+	intensity = jComponent[JSON_TAG_INTENSITY];
+	radius = jComponent[JSON_TAG_RADIUS];
+	useCustomFalloff = jComponent[JSON_TAG_USE_CUSTOM_FALLOFF];
+	falloffExponent = jComponent[JSON_TAG_FALLOFF_EXPONENT];
+	innerAngle = jComponent[JSON_TAG_INNER_ANGLE];
+	outerAngle = jComponent[JSON_TAG_OUTER_ANGLE];
 }
 
 void ComponentLight::UpdateLight() {

--- a/Project/Source/Components/ComponentLight.h
+++ b/Project/Source/Components/ComponentLight.h
@@ -31,11 +31,10 @@ public:
 	float3 color = {1.0f, 1.0f, 1.0f};			  // RGB color that will be reflected in the objects.
 
 	// -------- Attenuation -------- //
-	// Inital default values to rise 100 meters.
 	float intensity = 1.0f;
-	float kc = 1.0f;		//Keep in one to avoid having denominator less than 1
-	float kl = 0.045f;
-	float kq = 0.0075f;
+	float radius = 1.0f;
+	bool useCustomFalloff = false;
+	float falloffExponent = 1.0f;
 	float innerAngle = pi / 12;
 	float outerAngle = pi / 6;
 };

--- a/Project/Source/Components/ComponentMeshRenderer.cpp
+++ b/Project/Source/Components/ComponentMeshRenderer.cpp
@@ -568,12 +568,15 @@ void ComponentMeshRenderer::Draw(const float4x4& modelMatrix) const {
 	glUniform2fv(standardProgram->offsetLocation, 1, material->offset.ptr());
 
 	// IBL textures
-	auto it = scene->skyboxComponents.begin();
-	if (it != scene->skyboxComponents.end()) {
-		ComponentSkyBox& skyboxComponent = *it;
+	auto skyboxIt = scene->skyboxComponents.begin();
+	bool hasIBL = false;
+	if (skyboxIt != scene->skyboxComponents.end()) {
+		ComponentSkyBox& skyboxComponent = *skyboxIt;
 		ResourceSkybox* skyboxResource = App->resources->GetResource<ResourceSkybox>(skyboxComponent.GetSkyboxResourceID());
 
 		if (skyboxResource != nullptr) {
+			hasIBL = true;
+
 			glUniform1i(standardProgram->diffuseIBLLocation, 7);
 			glActiveTexture(GL_TEXTURE7);
 			glBindTexture(GL_TEXTURE_CUBE_MAP, skyboxResource->GetGlIrradianceMap());
@@ -587,12 +590,15 @@ void ComponentMeshRenderer::Draw(const float4x4& modelMatrix) const {
 			glBindTexture(GL_TEXTURE_2D, skyboxResource->GetGlEnvironmentBRDF());
 
 			glUniform1i(standardProgram->prefilteredIBLNumLevelsLocation, skyboxResource->GetPreFilteredMapNumLevels());
+
+			glUniform1f(standardProgram->strengthIBLLocation, skyboxComponent.strength);
 		}
 	}
+	glUniform1i(standardProgram->hasIBLLocation, hasIBL ? 1 : 0);
+
 	// Lights uniforms settings
 	glUniform3fv(standardProgram->lightAmbientColorLocation, 1, App->renderer->ambientColor.ptr());
 
-	// Lights uniforms settings
 	if (directionalLight != nullptr) {
 		glUniform3fv(standardProgram->lightDirectionalDirectionLocation, 1, directionalLight->direction.ptr());
 		glUniform3fv(standardProgram->lightDirectionalColorLocation, 1, directionalLight->color.ptr());

--- a/Project/Source/Components/ComponentMeshRenderer.cpp
+++ b/Project/Source/Components/ComponentMeshRenderer.cpp
@@ -604,9 +604,9 @@ void ComponentMeshRenderer::Draw(const float4x4& modelMatrix) const {
 		glUniform3fv(standardProgram->lightPoints[i].posLocation, 1, pointLightsArray[i]->pos.ptr());
 		glUniform3fv(standardProgram->lightPoints[i].colorLocation, 1, pointLightsArray[i]->color.ptr());
 		glUniform1f(standardProgram->lightPoints[i].intensityLocation, pointLightsArray[i]->intensity);
-		glUniform1f(standardProgram->lightPoints[i].kcLocation, pointLightsArray[i]->kc);
-		glUniform1f(standardProgram->lightPoints[i].klLocation, pointLightsArray[i]->kl);
-		glUniform1f(standardProgram->lightPoints[i].kqLocation, pointLightsArray[i]->kq);
+		glUniform1f(standardProgram->lightPoints[i].radiusLocation, pointLightsArray[i]->radius);
+		glUniform1i(standardProgram->lightPoints[i].useCustomFalloffLocation, pointLightsArray[i]->useCustomFalloff);
+		glUniform1f(standardProgram->lightPoints[i].falloffExponentLocation, pointLightsArray[i]->falloffExponent);
 	}
 	glUniform1i(standardProgram->lightNumPointsLocation, pointLightsArraySize);
 
@@ -615,9 +615,9 @@ void ComponentMeshRenderer::Draw(const float4x4& modelMatrix) const {
 		glUniform3fv(standardProgram->lightSpots[i].directionLocation, 1, spotLightsArray[i]->direction.ptr());
 		glUniform3fv(standardProgram->lightSpots[i].colorLocation, 1, spotLightsArray[i]->color.ptr());
 		glUniform1f(standardProgram->lightSpots[i].intensityLocation, spotLightsArray[i]->intensity);
-		glUniform1f(standardProgram->lightSpots[i].kcLocation, spotLightsArray[i]->kc);
-		glUniform1f(standardProgram->lightSpots[i].klLocation, spotLightsArray[i]->kl);
-		glUniform1f(standardProgram->lightSpots[i].kqLocation, spotLightsArray[i]->kq);
+		glUniform1f(standardProgram->lightSpots[i].radiusLocation, spotLightsArray[i]->radius);
+		glUniform1i(standardProgram->lightSpots[i].useCustomFalloffLocation, spotLightsArray[i]->useCustomFalloff);
+		glUniform1f(standardProgram->lightSpots[i].falloffExponentLocation, spotLightsArray[i]->falloffExponent);
 		glUniform1f(standardProgram->lightSpots[i].innerAngleLocation, spotLightsArray[i]->innerAngle);
 		glUniform1f(standardProgram->lightSpots[i].outerAngleLocation, spotLightsArray[i]->outerAngle);
 	}

--- a/Project/Source/Components/ComponentSkyBox.cpp
+++ b/Project/Source/Components/ComponentSkyBox.cpp
@@ -15,10 +15,12 @@
 
 #define JSON_TAG_SHADER "Shader"
 #define JSON_TAG_SKYBOX "Skybox"
+#define JSON_TAG_STRENGTH "Strength"
 
 void ComponentSkyBox::Save(JsonValue jComponent) const {
 	jComponent[JSON_TAG_SHADER] = shaderId;
 	jComponent[JSON_TAG_SKYBOX] = skyboxId;
+	jComponent[JSON_TAG_STRENGTH] = strength;
 }
 
 void ComponentSkyBox::Load(JsonValue jComponent) {
@@ -26,6 +28,7 @@ void ComponentSkyBox::Load(JsonValue jComponent) {
 	if (shaderId != 0) App->resources->IncreaseReferenceCount(shaderId);
 	skyboxId = jComponent[JSON_TAG_SKYBOX];
 	if (skyboxId != 0) App->resources->IncreaseReferenceCount(skyboxId);
+	strength = jComponent[JSON_TAG_STRENGTH];
 }
 
 void ComponentSkyBox::OnEditorUpdate() {
@@ -40,6 +43,7 @@ void ComponentSkyBox::OnEditorUpdate() {
 	}
 	ImGui::Separator();
 	ImGui::ResourceSlot<ResourceSkybox>("Skybox", &skyboxId);
+	ImGui::DragFloat("Strength", &strength, App->editor->dragSpeed2f, 0.0f, inf);
 }
 
 void ComponentSkyBox::Draw() {

--- a/Project/Source/Components/ComponentSkyBox.h
+++ b/Project/Source/Components/ComponentSkyBox.h
@@ -14,6 +14,9 @@ public:
 
 	UID GetSkyboxResourceID();
 
+public:
+	float strength = 1.0f;
+
 private:
 	UID shaderId = 0;
 	UID skyboxId = 0;

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -131,10 +131,12 @@ ProgramStandard::ProgramStandard(unsigned program_)
 	tilingLocation = glGetUniformLocation(program, "tiling");
 	offsetLocation = glGetUniformLocation(program, "offset");
 
+	hasIBLLocation = glGetUniformLocation(program, "hasIBL");
 	diffuseIBLLocation = glGetUniformLocation(program, "diffuseIBL");
 	prefilteredIBLLocation = glGetUniformLocation(program, "prefilteredIBL");
 	environmentBRDFLocation = glGetUniformLocation(program, "environmentBRDF");
 	prefilteredIBLNumLevelsLocation = glGetUniformLocation(program, "prefilteredIBLNumLevels");
+	strengthIBLLocation = glGetUniformLocation(program, "strengthIBL");
 
 	lightAmbientColorLocation = glGetUniformLocation(program, "light.ambient.color");
 

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -9,9 +9,9 @@ PointLightUniforms::PointLightUniforms(unsigned program, unsigned number) {
 	posLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].pos").c_str());
 	colorLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].color").c_str());
 	intensityLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].intensity").c_str());
-	kcLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].kc").c_str());
-	klLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].kl").c_str());
-	kqLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].kq").c_str());
+	radiusLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].radius").c_str());
+	useCustomFalloffLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].useCustomFalloff").c_str());
+	falloffExponentLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].falloffExponent").c_str());
 }
 
 SpotLightUniforms::SpotLightUniforms() {}
@@ -21,9 +21,9 @@ SpotLightUniforms::SpotLightUniforms(unsigned program, unsigned number) {
 	directionLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].direction").c_str());
 	colorLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].color").c_str());
 	intensityLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].intensity").c_str());
-	kcLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].kc").c_str());
-	klLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].kl").c_str());
-	kqLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].kq").c_str());
+	radiusLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].radius").c_str());
+	useCustomFalloffLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].useCustomFalloff").c_str());
+	falloffExponentLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].falloffExponent").c_str());
 	innerAngleLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].innerAngle").c_str());
 	outerAngleLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].outerAngle").c_str());
 }

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -138,10 +138,12 @@ struct ProgramStandard : public Program {
 	int tilingLocation = -1;
 	int offsetLocation = -1;
 
+	int hasIBLLocation = -1;
 	int diffuseIBLLocation = -1;
 	int prefilteredIBLLocation = -1;
 	int environmentBRDFLocation = -1;
 	int prefilteredIBLNumLevelsLocation = -1;
+	int strengthIBLLocation = -1;
 
 	int lightAmbientColorLocation = -1;
 

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -9,9 +9,9 @@ struct PointLightUniforms {
 	int posLocation = -1;
 	int colorLocation = -1;
 	int intensityLocation = -1;
-	int kcLocation = -1;
-	int klLocation = -1;
-	int kqLocation = -1;
+	int radiusLocation = -1;
+	int useCustomFalloffLocation = -1;
+	int falloffExponentLocation = -1;
 };
 
 struct SpotLightUniforms {
@@ -22,9 +22,9 @@ struct SpotLightUniforms {
 	int directionLocation = -1;
 	int colorLocation = -1;
 	int intensityLocation = -1;
-	int kcLocation = -1;
-	int klLocation = -1;
-	int kqLocation = -1;
+	int radiusLocation = -1;
+	int useCustomFalloffLocation = -1;
+	int falloffExponentLocation = -1;
 	int innerAngleLocation = -1;
 	int outerAngleLocation = -1;
 };


### PR DESCRIPTION
Lights will now attenuate in a more physically accurate way. There is an added checkbox to use an exponential falloff if necessary.
- Point lights and Spotlights now use lumens as the intensity unit.
- Light attenuation is the same for all lights unless stated otherwise (using a custom falloff)
- Added a range for lights. This range doesn't affect the intensity of the light unless an exponential falloff is used.
- Skyboxes now have an added strength parameter to change the power of the ambient lighting.

GAMEPLAY: This will require reworking the scene lighting to use the new parameters.

![image](https://imgur.com/caIGpPB.png)