### PR TITLE
Fix texture compression

### DIFF
--- a/Project/Source/FileSystem/TextureImporter.cpp
+++ b/Project/Source/FileSystem/TextureImporter.cpp
@@ -129,20 +129,26 @@ bool TextureImporter::ImportTexture(const char* filePath, JsonValue jMeta) {
 		return false;
 	}
 
+	// Flip image if neccessary
+	ILinfo info;
+	iluGetImageInfo(&info);
+	if (info.Origin == IL_ORIGIN_UPPER_LEFT) {
+		iluFlipImage();
+	}
+
 	// Flip if asked to
 	if (importOptions->flip) {
 		iluFlipImage();
 	}
 
 	// Save image
-	ilSetInteger(IL_DXTC_FORMAT, IL_DXT5);
-	size_t size = ilSaveL(IL_DDS, nullptr, 0);
+	size_t size = ilSaveL(IL_RAW, nullptr, 0);
 	if (size == 0) {
 		LOG("Failed to save image.");
 		return false;
 	}
 	Buffer<char> buffer = Buffer<char>(size);
-	size = ilSaveL(IL_DDS, buffer.Data(), size);
+	size = ilSaveL(IL_RAW, buffer.Data(), size);
 	if (size == 0) {
 		LOG("Failed to save image.");
 		return false;

--- a/Project/Source/Resources/ResourceTexture.cpp
+++ b/Project/Source/Resources/ResourceTexture.cpp
@@ -39,17 +39,10 @@ void ResourceTexture::Load() {
 
 	// Load image
 	ilBindImage(image);
-	bool imageLoaded = ilLoad(IL_DDS, filePath.c_str());
+	bool imageLoaded = ilLoad(IL_RAW, filePath.c_str());
 	if (!imageLoaded) {
 		LOG("Failed to load image.");
 		return;
-	}
-
-	// Flip image if neccessary
-	ILinfo info;
-	iluGetImageInfo(&info);
-	if (info.Origin == IL_ORIGIN_UPPER_LEFT) {
-		iluFlipImage();
 	}
 
 	// Generate texture from image


### PR DESCRIPTION
Textures were being compressed on import, which is not the default behavior we want. This fixes multiple visual problems with the scene, including:
- Textures having improper colors
- Normal mapping artifacts

It would be a good idea to allow compression / decompression of individual textures, but this will be done separately.