### PR TITLE
NavMesh Raycast query function

### DIFF
--- a/Project/Source/GameplaySystems.cpp
+++ b/Project/Source/GameplaySystems.cpp
@@ -15,6 +15,7 @@
 #include "Modules/ModuleCamera.h"
 #include "Modules/ModuleAudio.h"
 #include "Modules/ModuleUserInterface.h"
+#include "Modules/ModuleNavigation.h"
 #include "Resources/ResourcePrefab.h"
 #include "Resources/ResourceMaterial.h"
 #include "Resources/ResourceClip.h"
@@ -474,4 +475,10 @@ void Audio::StopAllSources() {
 
 ComponentEventSystem* UserInterface::GetCurrentEventSystem() {
 	return App->userInterface->GetCurrentEventSystem();
+}
+
+void Navigation::Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition) {
+	if (App->navigation != nullptr) {
+		App->navigation->Raycast(startPosition, targetPosition, hitResult, hitPosition);
+	}
 }

--- a/Project/Source/GameplaySystems.h
+++ b/Project/Source/GameplaySystems.h
@@ -523,3 +523,7 @@ namespace Audio {
 namespace UserInterface {
 	TESSERACT_ENGINE_API ComponentEventSystem* GetCurrentEventSystem();
 }; // namespace UserInterface
+
+namespace Navigation {
+	TESSERACT_ENGINE_API void Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition);
+}

--- a/Project/Source/Modules/ModuleNavigation.cpp
+++ b/Project/Source/Modules/ModuleNavigation.cpp
@@ -8,6 +8,7 @@
 #include "Modules/ModuleScene.h"
 #include "Components/ComponentAgent.h"
 #include "Scene.h"
+#include "Detour/DetourCommon.h"
 #include "Utils/Logging.h"
 
 #include "Utils/Leaks.h"
@@ -70,4 +71,67 @@ void ModuleNavigation::DrawGizmos() {
 
 NavMesh& ModuleNavigation::GetNavMesh() {
 	return navMesh;
+}
+
+void ModuleNavigation::Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition) {
+	hitResult = false;
+	hitPosition = targetPosition;
+
+	if (!navMesh.IsGenerated()) return;
+
+	dtNavMeshQuery* navQuery = navMesh.GetNavMeshQuery();
+	if (navQuery == nullptr) return;
+
+	float3 m_polyPickExt = float3(2, 4, 2);
+	dtQueryFilter m_filter;
+	m_filter.setIncludeFlags(0xffff ^ 0x10);	// SAMPLE_POLYFLAGS_ALL ^ SAMPLE_POLYFLAGS_DISABLED
+	m_filter.setExcludeFlags(0);
+	m_filter.setAreaCost(0, 1.0f);	// SAMPLE_POLYAREA_GROUND
+	m_filter.setAreaCost(1, 10.0f);	// SAMPLE_POLYAREA_WATER
+	m_filter.setAreaCost(2, 1.0f);	// SAMPLE_POLYAREA_ROAD
+	m_filter.setAreaCost(3, 1.0f);	// SAMPLE_POLYAREA_DOOR
+	m_filter.setAreaCost(4, 2.0f);	// SAMPLE_POLYAREA_GRASS
+	m_filter.setAreaCost(5, 1.5f);	// SAMPLE_POLYAREA_JUMP
+
+	dtPolyRef m_startRef;
+	navQuery->findNearestPoly(startPosition.ptr(), m_polyPickExt.ptr(), &m_filter, &m_startRef, 0);
+
+	dtPolyRef m_endRef;
+	navQuery->findNearestPoly(targetPosition.ptr(), m_polyPickExt.ptr(), &m_filter, &m_endRef, 0);
+
+	float m_nstraightPath = 0;
+	if (m_startRef) {
+
+		float t = 0;
+		int m_npolys = 0;
+		int m_nstraightPath = 2;
+		static const int MAX_POLYS = 256;
+		float m_straightPath[MAX_POLYS * 3];
+		m_straightPath[0] = startPosition[0];
+		m_straightPath[1] = startPosition[1];
+		m_straightPath[2] = startPosition[2];
+
+		dtPolyRef m_polys[MAX_POLYS];
+
+		float3 m_hitNormal;
+
+		navQuery->raycast(m_startRef, startPosition.ptr(), targetPosition.ptr(), &m_filter, &t, m_hitNormal.ptr(), m_polys, &m_npolys, MAX_POLYS);
+		if (t > 1) {
+			// No hit
+			dtVcopy(hitPosition.ptr(), targetPosition.ptr());
+			hitResult = false;
+		} else {
+			// Hit
+			dtVlerp(hitPosition.ptr(), startPosition.ptr(), targetPosition.ptr(), t);
+			hitResult = true;
+		}
+		// Adjust height.
+		// OPTIONAL
+		/*if (m_npolys > 0) {
+			float h = 0;
+			navQuery->getPolyHeight(m_polys[m_npolys - 1], hitPosition.ptr(), &h);
+			hitPosition[1] = h;
+		}
+		dtVcopy(&m_straightPath[3], hitPosition.ptr());*/
+	}
 }

--- a/Project/Source/Modules/ModuleNavigation.cpp
+++ b/Project/Source/Modules/ModuleNavigation.cpp
@@ -75,47 +75,37 @@ NavMesh& ModuleNavigation::GetNavMesh() {
 
 void ModuleNavigation::Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition) {
 	hitResult = false;
-	hitPosition = targetPosition;
+	hitPosition = startPosition;
 
 	if (!navMesh.IsGenerated()) return;
 
 	dtNavMeshQuery* navQuery = navMesh.GetNavMeshQuery();
 	if (navQuery == nullptr) return;
 
-	float3 m_polyPickExt = float3(2, 4, 2);
-	dtQueryFilter m_filter;
-	m_filter.setIncludeFlags(0xffff ^ 0x10);	// SAMPLE_POLYFLAGS_ALL ^ SAMPLE_POLYFLAGS_DISABLED
-	m_filter.setExcludeFlags(0);
-	m_filter.setAreaCost(0, 1.0f);	// SAMPLE_POLYAREA_GROUND
-	m_filter.setAreaCost(1, 10.0f);	// SAMPLE_POLYAREA_WATER
-	m_filter.setAreaCost(2, 1.0f);	// SAMPLE_POLYAREA_ROAD
-	m_filter.setAreaCost(3, 1.0f);	// SAMPLE_POLYAREA_DOOR
-	m_filter.setAreaCost(4, 2.0f);	// SAMPLE_POLYAREA_GRASS
-	m_filter.setAreaCost(5, 1.5f);	// SAMPLE_POLYAREA_JUMP
+	float3 polyPickExt = float3(2, 4, 2);
+	dtQueryFilter filter;
+	filter.setIncludeFlags(0xffff ^ 0x10); // SAMPLE_POLYFLAGS_ALL ^ SAMPLE_POLYFLAGS_DISABLED
+	filter.setExcludeFlags(0);
+	filter.setAreaCost(0, 1.0f);	// SAMPLE_POLYAREA_GROUND
+	filter.setAreaCost(1, 10.0f);	// SAMPLE_POLYAREA_WATER
+	filter.setAreaCost(2, 1.0f);	// SAMPLE_POLYAREA_ROAD
+	filter.setAreaCost(3, 1.0f);	// SAMPLE_POLYAREA_DOOR
+	filter.setAreaCost(4, 2.0f);	// SAMPLE_POLYAREA_GRASS
+	filter.setAreaCost(5, 1.5f);	// SAMPLE_POLYAREA_JUMP
 
-	dtPolyRef m_startRef;
-	navQuery->findNearestPoly(startPosition.ptr(), m_polyPickExt.ptr(), &m_filter, &m_startRef, 0);
+	dtPolyRef startRef;
+	navQuery->findNearestPoly(startPosition.ptr(), polyPickExt.ptr(), &filter, &startRef, 0);
 
-	dtPolyRef m_endRef;
-	navQuery->findNearestPoly(targetPosition.ptr(), m_polyPickExt.ptr(), &m_filter, &m_endRef, 0);
-
-	float m_nstraightPath = 0;
-	if (m_startRef) {
-
+	if (startRef) {
 		float t = 0;
-		int m_npolys = 0;
-		int m_nstraightPath = 2;
+		int npolys = 0;
 		static const int MAX_POLYS = 256;
-		float m_straightPath[MAX_POLYS * 3];
-		m_straightPath[0] = startPosition[0];
-		m_straightPath[1] = startPosition[1];
-		m_straightPath[2] = startPosition[2];
 
-		dtPolyRef m_polys[MAX_POLYS];
+		dtPolyRef polys[MAX_POLYS];
 
-		float3 m_hitNormal;
+		float3 hitNormal;
 
-		navQuery->raycast(m_startRef, startPosition.ptr(), targetPosition.ptr(), &m_filter, &t, m_hitNormal.ptr(), m_polys, &m_npolys, MAX_POLYS);
+		navQuery->raycast(startRef, startPosition.ptr(), targetPosition.ptr(), &filter, &t, hitNormal.ptr(), polys, &npolys, MAX_POLYS);
 		if (t > 1) {
 			// No hit
 			dtVcopy(hitPosition.ptr(), targetPosition.ptr());
@@ -125,13 +115,5 @@ void ModuleNavigation::Raycast(float3 startPosition, float3 targetPosition, bool
 			dtVlerp(hitPosition.ptr(), startPosition.ptr(), targetPosition.ptr(), t);
 			hitResult = true;
 		}
-		// Adjust height.
-		// OPTIONAL
-		/*if (m_npolys > 0) {
-			float h = 0;
-			navQuery->getPolyHeight(m_polys[m_npolys - 1], hitPosition.ptr(), &h);
-			hitPosition[1] = h;
-		}
-		dtVcopy(&m_straightPath[3], hitPosition.ptr());*/
 	}
 }

--- a/Project/Source/Modules/ModuleNavigation.h
+++ b/Project/Source/Modules/ModuleNavigation.h
@@ -6,6 +6,7 @@
 #include "Navigation/NavMesh.h"
 #include "Resources/ResourceNavMesh.h"
 #include "DetourCrowd/DetourCrowd.h"
+#include "Math/float3.h"
 
 class ModuleNavigation : public Module {
 public:
@@ -17,6 +18,7 @@ public:
 	
 	void DrawGizmos();				// Draws NavMesh Gizmos
 	NavMesh& GetNavMesh();			// Returns navMesh
+	void Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition);
 
 private:
 	NavMesh navMesh;

--- a/Project/Source/Modules/ModuleNavigation.h
+++ b/Project/Source/Modules/ModuleNavigation.h
@@ -18,7 +18,7 @@ public:
 	
 	void DrawGizmos();				// Draws NavMesh Gizmos
 	NavMesh& GetNavMesh();			// Returns navMesh
-	void Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition);
+	void Raycast(float3 startPosition, float3 targetPosition, bool& hitResult, float3& hitPosition);	// Shoots a raycast between startPosition and targetPosition and detects if there's a wall/obstacle between. Hitresult is set to true and hitPosition is the position where the wall has been detected
 
 private:
 	NavMesh navMesh;


### PR DESCRIPTION
Added Raycast query function for wall detection of the NavMesh. This was requested by @GBMiro in order to detect the furthest position the enemies can be pushed by Fang's Push ability.
This function can be called from Gameplay with the new namespace Navigation just like this:
`Navigation::Raycast(float3 source, float3 target, bool hasHit, float3 hitPosition);` 

A quick test can be seen in the next GIF: 
- X Positive is right
- Source position is the bottom of the gif.

![1b7a3b19c7ffa99d099b0a21c5192761](https://user-images.githubusercontent.com/27434068/127780334-2290b696-143e-4381-b6bb-a60b1b8c25f3.gif)
