### PR TITLE
Scripts Members Separator

### DIFF
--- a/Project/Source/Components/ComponentScript.cpp
+++ b/Project/Source/Components/ComponentScript.cpp
@@ -195,6 +195,13 @@ void ComponentScript::OnEditorUpdate() {
 				}
 				break;
 			}
+			case MemberType::SEPARATOR: {
+				ImGui::Text("");
+				ImGui::Separator();
+				ImGui::TextColored(App->editor->memberSeparatorTextColor, member.name.c_str());
+				ImGui::Text("");
+				break;
+			}
 			default:
 				LOG("Member of type %i hasn't been registered in ComponentScript's OnEditorUpdate function.", (unsigned) member.type);
 				assert(false); // ERROR: Member type not registered

--- a/Project/Source/Modules/ModuleEditor.h
+++ b/Project/Source/Modules/ModuleEditor.h
@@ -80,6 +80,7 @@ public:
 	UID selectedResource = 0;							   // Currently selected resource in the PanelProject.
 	ImVec4 titleColor = ImVec4(0.35f, 0.69f, 0.87f, 1.0f); // Color used for the titles in ImGui
 	ImVec4 textColor = ImVec4(0.5f, 0.5f, 0.5f, 1.0f);	   // Color used for text and information in ImGui
+	ImVec4 memberSeparatorTextColor = ImVec4(0.27f, 0.55f, 1.0f, 1.0f); // Color used for the name of the Separator in Members of Script
 
 	// --- Float Sliders speeds ---- //
 	float dragSpeed1f = 0.5f;

--- a/Project/Source/Scripting/Member.cpp
+++ b/Project/Source/Scripting/Member.cpp
@@ -34,6 +34,8 @@ const char* GetMemberTypeName(MemberType type) {
 		return "PrefabResourceUID";
 	case MemberType::SCENE_RESOURCE_UID:
 		return "SceneResourceUID";
+	case MemberType::SEPARATOR:
+		return "Separator";
 	default:
 		LOG("Member of type %i hasn't been registered in GetMemberTypeName.", (unsigned) type);
 		assert(false); // ERROR: Member type not registered
@@ -68,6 +70,8 @@ MemberType GetMemberTypeFromName(const char* name) {
 		return MemberType::PREFAB_RESOURCE_UID;
 	} else if (strcmp(name, "SceneResourceUID") == 0) {
 		return MemberType::SCENE_RESOURCE_UID;
+	} else if (strcmp(name, "Separator") == 0) {
+		return MemberType::SEPARATOR;
 	} else {
 		LOG("No member of name %s exists.", (unsigned) name);
 		assert(false); // ERROR: Invalid name

--- a/Project/Source/Scripting/Member.h
+++ b/Project/Source/Scripting/Member.h
@@ -14,6 +14,9 @@
 #define MEMBER(type, member) \
 	Member(type, #member, offsetof(ClassType, member))
 
+#define MEMBER_SEPARATOR(name) \
+	Member(MemberType::SEPARATOR, name, 0)
+
 #define GET_OFFSET_MEMBER(script, offset) \
 	(((char*) script) + offset)
 
@@ -45,7 +48,10 @@ enum class MemberType {
 
 	// Resources
 	PREFAB_RESOURCE_UID,
-	SCENE_RESOURCE_UID
+	SCENE_RESOURCE_UID,
+
+	// Separator
+	SEPARATOR
 };
 
 struct Member {
@@ -53,6 +59,10 @@ struct Member {
 		: type(type_)
 		, name(name_)
 		, offset(offset_) {}
+
+	Member(MemberType type_, std::string name_)
+		: type(type_)
+		, name(name_) {}
 
 	MemberType type;
 	std::string name;


### PR DESCRIPTION
Added a new Expose Member function to separate Script's variables.

This is the result:

![image](https://user-images.githubusercontent.com/27434068/127783160-1798b784-b08d-4b55-be3c-f5e5f7b23f78.png)

Generated by the following code:

![image](https://user-images.githubusercontent.com/27434068/127783165-932ae82f-61bc-4255-992b-70422a6ff5c8.png)
