### PR TITLE
Chromatic aberration implementation

### DIFF
--- a/Game/Assets/Shaders/colorCorrection.shader
+++ b/Game/Assets/Shaders/colorCorrection.shader
@@ -29,6 +29,9 @@ uniform int smallMipLevel;
 uniform int mediumMipLevel;
 uniform int largeMipLevel;
 
+uniform int hasChromaticAberration;
+uniform float chromaticAberrationStrength;
+
 vec3 ACESFilm(in vec3 x) {
 	float a = 2.51f;
 	float b = 0.03f;
@@ -41,6 +44,16 @@ vec3 ACESFilm(in vec3 x) {
 void main()
 {
 	vec4 hdrColor = texture(scene, uv);
+
+	// Apply chromatic aberration
+	if (hasChromaticAberration == 1) {
+		vec2 d = ((uv - vec2(.5)) * .0075) * chromaticAberrationStrength;
+		vec3 color = vec3(texture(scene, uv - 0.0 * d).r,
+			texture(scene, uv - 1.0 * d).g,
+			texture(scene, uv - 2.0 * d).b);
+
+		hdrColor = vec4(color, hdrColor.a);
+	}
 
 	// Apply bloom
 	if (hasBloomBlur == 1) {

--- a/Project/Source/GameplaySystems.cpp
+++ b/Project/Source/GameplaySystems.cpp
@@ -467,6 +467,22 @@ void Screen::SetBloomThreshold(float value) {
 	App->renderer->bloomThreshold = value;
 }
 
+const bool Screen::IsChromaticAberrationActive() {
+	return App->renderer->chromaticAberrationActive;
+}
+
+void Screen::SetChromaticAberration(bool value) {
+	App->renderer->chromaticAberrationActive = value;
+}
+
+const float Screen::GetChromaticAberrationStrength() {
+	return App->renderer->chromaticAberrationActive;
+}
+
+void Screen::SetChromaticAberrationStrength(float value) {
+	App->renderer->chromaticAberrationStrength = value;
+}
+
 // --------- Camera --------- //
 
 bool Camera::CheckObjectInsideFrustum(GameObject* gameObject) {

--- a/Project/Source/GameplaySystems.cpp
+++ b/Project/Source/GameplaySystems.cpp
@@ -476,7 +476,7 @@ void Screen::SetChromaticAberration(bool value) {
 }
 
 const float Screen::GetChromaticAberrationStrength() {
-	return App->renderer->chromaticAberrationActive;
+	return App->renderer->chromaticAberrationStrength;
 }
 
 void Screen::SetChromaticAberrationStrength(float value) {

--- a/Project/Source/GameplaySystems.h
+++ b/Project/Source/GameplaySystems.h
@@ -490,6 +490,11 @@ namespace Screen {
 	TESSERACT_ENGINE_API const float GetBloomThreshold();
 	TESSERACT_ENGINE_API void SetBloomThreshold(float value);
 
+	TESSERACT_ENGINE_API const bool IsChromaticAberrationActive();
+	TESSERACT_ENGINE_API void SetChromaticAberration(bool value);
+	TESSERACT_ENGINE_API const float GetChromaticAberrationStrength();
+	TESSERACT_ENGINE_API void SetChromaticAberrationStrength(float value);
+
 }; // namespace Screen
 
 namespace SceneManager {

--- a/Project/Source/Modules/ModuleConfiguration.cpp
+++ b/Project/Source/Modules/ModuleConfiguration.cpp
@@ -37,6 +37,8 @@
 #define JSON_TAG_BLOOM_LARGE_WEIGHT "BloomLargeWeight"
 #define JSON_TAG_MSAA_ACTIVE "MSAAActive"
 #define JSON_TAG_MSAA_SAMPLE_TYPE "MSAASampleType"
+#define JSON_TAG_CHROMATIC_ABERRATION_ACTIVE "ChromaticAberrationActive"
+#define JSON_TAG_CHROMATIC_ABERRATION_STRENGTH "ChromaticAberrationStrength"
 
 bool ModuleConfiguration::Init() {
 	LoadConfiguration();
@@ -95,6 +97,9 @@ void ModuleConfiguration::LoadConfiguration() {
 	App->renderer->msaaActive = jConfig[JSON_TAG_MSAA_ACTIVE];
 	App->renderer->msaaSampleType = (MSAA_SAMPLES_TYPE)(int) jConfig[JSON_TAG_MSAA_SAMPLE_TYPE];
 
+	App->renderer->chromaticAberrationActive = jConfig[JSON_TAG_CHROMATIC_ABERRATION_ACTIVE];
+	App->renderer->chromaticAberrationStrength = jConfig[JSON_TAG_CHROMATIC_ABERRATION_STRENGTH];
+
 	unsigned timeMs = timer.Stop();
 	LOG("Configuration loaded in %ums.", timeMs);
 }
@@ -139,6 +144,9 @@ void ModuleConfiguration::SaveConfiguration() {
 
 	jConfig[JSON_TAG_MSAA_ACTIVE] = App->renderer->msaaActive;
 	jConfig[JSON_TAG_MSAA_SAMPLE_TYPE] = (int) App->renderer->msaaSampleType;
+
+	jConfig[JSON_TAG_CHROMATIC_ABERRATION_ACTIVE] = App->renderer->chromaticAberrationActive;
+	jConfig[JSON_TAG_CHROMATIC_ABERRATION_STRENGTH] = App->renderer->chromaticAberrationStrength;
 
 	// Write document to buffer
 	rapidjson::StringBuffer stringBuffer;

--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -429,6 +429,9 @@ void ModuleRender::ExecuteColorCorrection(bool horizontal) {
 	glUniform1i(colorCorrectionProgram->mediumMipLevelLocation, gaussMediumMipLevel);
 	glUniform1i(colorCorrectionProgram->largeMipLevelLocation, gaussLargeMipLevel);
 
+	glUniform1i(colorCorrectionProgram->hasChromaticAberrationLocation, chromaticAberrationActive ? 1 : 0);
+	glUniform1f(colorCorrectionProgram->chromaticAberrationStrengthLocation, chromaticAberrationStrength);
+
 	glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 

--- a/Project/Source/Modules/ModuleRender.h
+++ b/Project/Source/Modules/ModuleRender.h
@@ -143,6 +143,9 @@ public:
 	int msaaSamplesNumber[static_cast<int>(MSAA_SAMPLES_TYPE::COUNT)] = {2, 4, 8};
 	int msaaSampleSingle = 1;
 
+	bool chromaticAberrationActive = false;
+	float chromaticAberrationStrength = 1.0f;
+
 	LightFrustum lightFrustum;
 
 private:

--- a/Project/Source/Panels/PanelConfiguration.cpp
+++ b/Project/Source/Panels/PanelConfiguration.cpp
@@ -265,6 +265,10 @@ void PanelConfiguration::Update() {
 				}
 				ImGui::EndCombo();
 			}
+
+			ImGui::Separator();
+			ImGui::Checkbox("Activate Chromatic Aberration", &App->renderer->chromaticAberrationActive);
+			ImGui::DragFloat("Chromatic Aberration Strength", &App->renderer->chromaticAberrationStrength, 0.1f);
 		}
 
 		// Scene

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -277,6 +277,9 @@ ProgramColorCorrection::ProgramColorCorrection(unsigned program_)
 	smallMipLevelLocation = glGetUniformLocation(program, "smallMipLevel");
 	mediumMipLevelLocation = glGetUniformLocation(program, "mediumMipLevel");
 	largeMipLevelLocation = glGetUniformLocation(program, "largeMipLevel");
+
+	hasChromaticAberrationLocation = glGetUniformLocation(program, "hasChromaticAberration");
+	chromaticAberrationStrengthLocation = glGetUniformLocation(program, "chromaticAberrationStrength");
 }
 
 ProgramHeightFog::ProgramHeightFog(unsigned program_)

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -291,6 +291,9 @@ struct ProgramColorCorrection : Program {
 	int smallMipLevelLocation = -1;
 	int mediumMipLevelLocation = -1;
 	int largeMipLevelLocation = -1;
+
+	int hasChromaticAberrationLocation = -1;
+	int chromaticAberrationStrengthLocation = -1;
 };
 
 struct ProgramHeightFog : Program {


### PR DESCRIPTION
Now Chromatic Aberration can be applied to the scene. Just like other postprocess/color correction settings, Chromatic Aberration can be set from Configuration tab.

**The default value to apply Chromatic Aberration Strength is 1. From 0 to 1 is an attenuated value, > 1 is an exaggerated value and < 0 may lead to unexpected results.**

![6b79bffb35558b5c45899c10fdb795e1](https://user-images.githubusercontent.com/27434068/128096709-a0a1557d-c13b-4dda-b62c-c55b525a615a.gif)

It can also be accessed from Gameplay with the following methods from the namespace Screen:

![image](https://user-images.githubusercontent.com/27434068/128096750-862a490f-aa80-4195-9b1b-3baa602f753a.png)
