### PR TITLE
Lights in Particle System

### DIFF
--- a/Game/Assets/Scenes/ParticleSystemTest.scene
+++ b/Game/Assets/Scenes/ParticleSystemTest.scene
@@ -7,7 +7,7 @@
     ],
     "QuadtreeMaxDepth": 4,
     "QuadtreeElementsPerNode": 200,
-    "GameCamera": 1071955167668248630,
+    "GameCamera": 4129849621672174128,
     "AmbientLight": [
         0.25,
         0.25,
@@ -97,8 +97,9 @@
                             1.0
                         ],
                         "Intensity": 1.0,
-                        "Kl": 0.04500000178813934,
-                        "Kq": 0.007499999832361937,
+                        "Radius": 0.0,
+                        "UseCustomFalloff": false,
+                        "FalloffExponent": 0.0,
                         "InnerAngle": 0.2617993950843811,
                         "OuterAngle": 0.5235987901687622
                     }
@@ -119,15 +120,15 @@
                         "Id": 13595604388018688839,
                         "Active": true,
                         "Position": [
-                            2.0,
-                            3.0,
-                            -5.0
+                            17.634000778198243,
+                            3.75,
+                            0.0
                         ],
                         "Rotation": [
                             0.0,
+                            -0.7071068286895752,
                             0.0,
-                            0.0,
-                            1.0
+                            0.7071068286895752
                         ],
                         "Scale": [
                             1.0,
@@ -136,7 +137,7 @@
                         ],
                         "LocalEulerAngles": [
                             -0.0,
-                            0.0,
+                            -90.0,
                             -0.0
                         ]
                     },
@@ -146,19 +147,19 @@
                         "Active": true,
                         "Frustum": {
                             "Pos": [
-                                2.0,
-                                3.0,
-                                -5.0
+                                17.634000778198243,
+                                3.75,
+                                0.0
                             ],
                             "Up": [
-                                0.0,
+                                -0.0,
                                 1.0,
                                 0.0
                             ],
                             "Front": [
+                                -0.9999999403953552,
                                 0.0,
-                                0.0,
-                                1.0
+                                -1.1920928955078126e-7
                             ],
                             "NearPlaneDistance": 0.10000000149011612,
                             "FarPlaneDistance": 2000.0,
@@ -171,7 +172,8 @@
                         "Id": 16249809570862807709,
                         "Active": true,
                         "Shader": 0,
-                        "Skybox": 0
+                        "Skybox": 0,
+                        "Strength": 0.0
                     },
                     {
                         "Type": "AudioListener",
@@ -399,6 +401,32 @@
                                         "HasCollision": true,
                                         "LayerIndex": 5,
                                         "CollRadius": 0.15000000596046449,
+                                        "HasTrail": false,
+                                        "TrailRatio": 0.0,
+                                        "WidthRM": 0,
+                                        "Width": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TrailQuadsRM": 0,
+                                        "TrailQuads": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "QuadLifeRM": 0,
+                                        "QuadLife": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TextureTrailID": 0,
+                                        "FlipTrailTexture": [
+                                            false,
+                                            false
+                                        ],
+                                        "TextureRepeats": 0,
+                                        "HasColorOverTrail": false,
+                                        "GradientColorsTrail": null,
+                                        "NumberColorsTrail": 0,
                                         "SubEmitters": [
                                             {
                                                 "GameObjectUID": 6545959193787736338,
@@ -406,7 +434,30 @@
                                                 "EmitProbability": 1.0
                                             }
                                         ],
-                                        "SubEmittersNumber": 1
+                                        "SubEmittersNumber": 1,
+                                        "HasLights": false,
+                                        "LightGameObjectUID": 0,
+                                        "LightsRatio": 0.0,
+                                        "LightsOffset": [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "IntensityMultiplierRM": 0,
+                                        "IntensityMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "RangeMultiplierRM": 0,
+                                        "RangeMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "UseParticleColor": false,
+                                        "UseCustomColor": false,
+                                        "GradientColorsLights": null,
+                                        "NumberColorsLights": 0,
+                                        "MaxLights": 0
                                     }
                                 ],
                                 "Children": null
@@ -551,8 +602,57 @@
                                         "HasCollision": false,
                                         "LayerIndex": 5,
                                         "CollRadius": 0.25,
+                                        "HasTrail": false,
+                                        "TrailRatio": 0.0,
+                                        "WidthRM": 0,
+                                        "Width": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TrailQuadsRM": 0,
+                                        "TrailQuads": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "QuadLifeRM": 0,
+                                        "QuadLife": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TextureTrailID": 0,
+                                        "FlipTrailTexture": [
+                                            false,
+                                            false
+                                        ],
+                                        "TextureRepeats": 0,
+                                        "HasColorOverTrail": false,
+                                        "GradientColorsTrail": null,
+                                        "NumberColorsTrail": 0,
                                         "SubEmitters": null,
-                                        "SubEmittersNumber": 0
+                                        "SubEmittersNumber": 0,
+                                        "HasLights": false,
+                                        "LightGameObjectUID": 0,
+                                        "LightsRatio": 0.0,
+                                        "LightsOffset": [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "IntensityMultiplierRM": 0,
+                                        "IntensityMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "RangeMultiplierRM": 0,
+                                        "RangeMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "UseParticleColor": false,
+                                        "UseCustomColor": false,
+                                        "GradientColorsLights": null,
+                                        "NumberColorsLights": 0,
+                                        "MaxLights": 0
                                     }
                                 ],
                                 "Children": null
@@ -793,6 +893,32 @@
                                         "HasCollision": true,
                                         "LayerIndex": 5,
                                         "CollRadius": 0.15000000596046449,
+                                        "HasTrail": false,
+                                        "TrailRatio": 0.0,
+                                        "WidthRM": 0,
+                                        "Width": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TrailQuadsRM": 0,
+                                        "TrailQuads": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "QuadLifeRM": 0,
+                                        "QuadLife": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TextureTrailID": 0,
+                                        "FlipTrailTexture": [
+                                            false,
+                                            false
+                                        ],
+                                        "TextureRepeats": 0,
+                                        "HasColorOverTrail": false,
+                                        "GradientColorsTrail": null,
+                                        "NumberColorsTrail": 0,
                                         "SubEmitters": [
                                             {
                                                 "GameObjectUID": 6545959193787736338,
@@ -800,7 +926,30 @@
                                                 "EmitProbability": 1.0
                                             }
                                         ],
-                                        "SubEmittersNumber": 1
+                                        "SubEmittersNumber": 1,
+                                        "HasLights": false,
+                                        "LightGameObjectUID": 0,
+                                        "LightsRatio": 0.0,
+                                        "LightsOffset": [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "IntensityMultiplierRM": 0,
+                                        "IntensityMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "RangeMultiplierRM": 0,
+                                        "RangeMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "UseParticleColor": false,
+                                        "UseCustomColor": false,
+                                        "GradientColorsLights": null,
+                                        "NumberColorsLights": 0,
+                                        "MaxLights": 0
                                     }
                                 ],
                                 "Children": null
@@ -945,8 +1094,57 @@
                                         "HasCollision": false,
                                         "LayerIndex": 5,
                                         "CollRadius": 0.25,
+                                        "HasTrail": false,
+                                        "TrailRatio": 0.0,
+                                        "WidthRM": 0,
+                                        "Width": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TrailQuadsRM": 0,
+                                        "TrailQuads": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "QuadLifeRM": 0,
+                                        "QuadLife": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TextureTrailID": 0,
+                                        "FlipTrailTexture": [
+                                            false,
+                                            false
+                                        ],
+                                        "TextureRepeats": 0,
+                                        "HasColorOverTrail": false,
+                                        "GradientColorsTrail": null,
+                                        "NumberColorsTrail": 0,
                                         "SubEmitters": null,
-                                        "SubEmittersNumber": 0
+                                        "SubEmittersNumber": 0,
+                                        "HasLights": false,
+                                        "LightGameObjectUID": 0,
+                                        "LightsRatio": 0.0,
+                                        "LightsOffset": [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "IntensityMultiplierRM": 0,
+                                        "IntensityMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "RangeMultiplierRM": 0,
+                                        "RangeMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "UseParticleColor": false,
+                                        "UseCustomColor": false,
+                                        "GradientColorsLights": null,
+                                        "NumberColorsLights": 0,
+                                        "MaxLights": 0
                                     }
                                 ],
                                 "Children": null
@@ -1130,6 +1328,32 @@
                                         "HasCollision": true,
                                         "LayerIndex": 5,
                                         "CollRadius": 0.15000000596046449,
+                                        "HasTrail": false,
+                                        "TrailRatio": 0.0,
+                                        "WidthRM": 0,
+                                        "Width": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TrailQuadsRM": 0,
+                                        "TrailQuads": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "QuadLifeRM": 0,
+                                        "QuadLife": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TextureTrailID": 0,
+                                        "FlipTrailTexture": [
+                                            false,
+                                            false
+                                        ],
+                                        "TextureRepeats": 0,
+                                        "HasColorOverTrail": false,
+                                        "GradientColorsTrail": null,
+                                        "NumberColorsTrail": 0,
                                         "SubEmitters": [
                                             {
                                                 "GameObjectUID": 6545959193787736338,
@@ -1137,7 +1361,30 @@
                                                 "EmitProbability": 1.0
                                             }
                                         ],
-                                        "SubEmittersNumber": 1
+                                        "SubEmittersNumber": 1,
+                                        "HasLights": false,
+                                        "LightGameObjectUID": 0,
+                                        "LightsRatio": 0.0,
+                                        "LightsOffset": [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "IntensityMultiplierRM": 0,
+                                        "IntensityMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "RangeMultiplierRM": 0,
+                                        "RangeMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "UseParticleColor": false,
+                                        "UseCustomColor": false,
+                                        "GradientColorsLights": null,
+                                        "NumberColorsLights": 0,
+                                        "MaxLights": 0
                                     }
                                 ],
                                 "Children": null
@@ -1282,13 +1529,536 @@
                                         "HasCollision": false,
                                         "LayerIndex": 5,
                                         "CollRadius": 0.25,
+                                        "HasTrail": false,
+                                        "TrailRatio": 0.0,
+                                        "WidthRM": 0,
+                                        "Width": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TrailQuadsRM": 0,
+                                        "TrailQuads": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "QuadLifeRM": 0,
+                                        "QuadLife": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "TextureTrailID": 0,
+                                        "FlipTrailTexture": [
+                                            false,
+                                            false
+                                        ],
+                                        "TextureRepeats": 0,
+                                        "HasColorOverTrail": false,
+                                        "GradientColorsTrail": null,
+                                        "NumberColorsTrail": 0,
                                         "SubEmitters": null,
-                                        "SubEmittersNumber": 0
+                                        "SubEmittersNumber": 0,
+                                        "HasLights": false,
+                                        "LightGameObjectUID": 0,
+                                        "LightsRatio": 0.0,
+                                        "LightsOffset": [
+                                            0.0,
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "IntensityMultiplierRM": 0,
+                                        "IntensityMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "RangeMultiplierRM": 0,
+                                        "RangeMultiplier": [
+                                            0.0,
+                                            0.0
+                                        ],
+                                        "UseParticleColor": false,
+                                        "UseCustomColor": false,
+                                        "GradientColorsLights": null,
+                                        "NumberColorsLights": 0,
+                                        "MaxLights": 0
                                     }
                                 ],
                                 "Children": null
                             }
                         ]
+                    }
+                ]
+            },
+            {
+                "Id": 2407099721860458062,
+                "Name": "Lights - Test",
+                "Active": true,
+                "Static": false,
+                "ActiveHierarchy": true,
+                "RootBoneId": 0,
+                "Mask": 0,
+                "Components": [
+                    {
+                        "Type": "Transform",
+                        "Id": 12442787724782949123,
+                        "Active": true,
+                        "Position": [
+                            1.3947504758834839,
+                            1.7016172409057618,
+                            -10.477377891540528
+                        ],
+                        "Rotation": [
+                            0.7071068286895752,
+                            0.0,
+                            0.0,
+                            0.7071068286895752
+                        ],
+                        "Scale": [
+                            1.0,
+                            1.0,
+                            1.0
+                        ],
+                        "LocalEulerAngles": [
+                            90.0,
+                            0.0,
+                            -0.0
+                        ]
+                    }
+                ],
+                "Children": [
+                    {
+                        "Id": 2108301588764095319,
+                        "Name": "ParticleSystem",
+                        "Active": true,
+                        "Static": false,
+                        "ActiveHierarchy": true,
+                        "RootBoneId": 0,
+                        "Mask": 0,
+                        "Components": [
+                            {
+                                "Type": "Transform",
+                                "Id": 4455837953886057174,
+                                "Active": true,
+                                "Position": [
+                                    0.0,
+                                    0.8160734176635742,
+                                    0.8723969459533691
+                                ],
+                                "Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "Scale": [
+                                    1.0,
+                                    1.0,
+                                    1.0
+                                ],
+                                "LocalEulerAngles": [
+                                    -0.0,
+                                    0.0,
+                                    -0.0
+                                ]
+                            },
+                            {
+                                "Type": "Particle",
+                                "Id": 13748261561062484852,
+                                "Active": true,
+                                "DrawGizmo": true,
+                                "Duration": 5.0,
+                                "Looping": true,
+                                "StartDelay": [
+                                    0.0,
+                                    0.0
+                                ],
+                                "LifeRM": 0,
+                                "Life": [
+                                    5.0,
+                                    5.0
+                                ],
+                                "SpeedRM": 0,
+                                "Speed": [
+                                    1.2999999523162842,
+                                    1.2999999523162842
+                                ],
+                                "RotationRM": 0,
+                                "Rotation": [
+                                    0.0,
+                                    0.0
+                                ],
+                                "ScaleRM": 0,
+                                "Scale": [
+                                    1.0,
+                                    1.0
+                                ],
+                                "ReverseEffect": false,
+                                "ReverseDistanceRM": 0,
+                                "ReverseDistance": [
+                                    5.0,
+                                    5.0
+                                ],
+                                "MaxParticle": 5,
+                                "PlayOnAwake": true,
+                                "AttachEmitter": true,
+                                "ParticlesPerSecondRM": 0,
+                                "ParticlesPerSecond": [
+                                    0.800000011920929,
+                                    10.0
+                                ],
+                                "GravityEffect": false,
+                                "GravityFactorRM": 0,
+                                "GravityFactor": [
+                                    0.0,
+                                    0.0
+                                ],
+                                "ParticleEmitterType": 0,
+                                "ConeRadiusUp": 0.0,
+                                "ConeRadiusDown": 0.0,
+                                "RandomConeRadiusUp": false,
+                                "RandomConeRadiusDown": false,
+                                "RotationOverLifetime": false,
+                                "RotationFactorRM": 0,
+                                "RotationFactor": [
+                                    0.0,
+                                    0.0
+                                ],
+                                "SizeOverLifetime": false,
+                                "ScaleFactorRM": 0,
+                                "ScaleFactor": [
+                                    0.0,
+                                    0.0
+                                ],
+                                "ColorOverLifetime": false,
+                                "GradientColors": [
+                                    [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0,
+                                        0.0
+                                    ],
+                                    [
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ]
+                                ],
+                                "NumberColors": 2,
+                                "Ytiles": 1,
+                                "Xtiles": 1,
+                                "AnimationSpeed": 0.0,
+                                "IsRandomFrame": false,
+                                "LoopAnimation": true,
+                                "NCycles": 1.0,
+                                "TextureId": 0,
+                                "BillboardType": 0,
+                                "ParticleRenderMode": 0,
+                                "ParticleRenderAlignment": 0,
+                                "FlipTexture": [
+                                    false,
+                                    false
+                                ],
+                                "IsSoft": false,
+                                "SoftRange": 1.0,
+                                "HasCollision": false,
+                                "LayerIndex": 5,
+                                "CollRadius": 0.25,
+                                "HasTrail": false,
+                                "TrailRatio": 1.0,
+                                "WidthRM": 0,
+                                "Width": [
+                                    0.10000000149011612,
+                                    0.10000000149011612
+                                ],
+                                "TrailQuadsRM": 0,
+                                "TrailQuads": [
+                                    50.0,
+                                    50.0
+                                ],
+                                "QuadLifeRM": 0,
+                                "QuadLife": [
+                                    10.0,
+                                    10.0
+                                ],
+                                "TextureTrailID": 0,
+                                "FlipTrailTexture": [
+                                    false,
+                                    false
+                                ],
+                                "TextureRepeats": 1,
+                                "HasColorOverTrail": false,
+                                "GradientColorsTrail": [
+                                    [
+                                        0.0,
+                                        0.0,
+                                        0.0,
+                                        1.0,
+                                        0.0
+                                    ],
+                                    [
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0,
+                                        1.0
+                                    ]
+                                ],
+                                "NumberColorsTrail": 2,
+                                "SubEmitters": null,
+                                "SubEmittersNumber": 0,
+                                "HasLights": true,
+                                "LightGameObjectUID": 14800951016291125013,
+                                "LightsRatio": 1.0,
+                                "LightsOffset": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "IntensityMultiplierRM": 0,
+                                "IntensityMultiplier": [
+                                    1.0,
+                                    1.4500000476837159
+                                ],
+                                "RangeMultiplierRM": 0,
+                                "RangeMultiplier": [
+                                    1.0,
+                                    1.0
+                                ],
+                                "UseParticleColor": false,
+                                "UseCustomColor": true,
+                                "GradientColorsLights": [
+                                    [
+                                        0.0,
+                                        0.25,
+                                        1.0,
+                                        1.0,
+                                        0.0
+                                    ],
+                                    [
+                                        0.0,
+                                        1.0,
+                                        0.454545259475708,
+                                        1.0,
+                                        1.0
+                                    ]
+                                ],
+                                "NumberColorsLights": 2,
+                                "MaxLights": 5
+                            }
+                        ],
+                        "Children": null
+                    },
+                    {
+                        "Id": 14800951016291125013,
+                        "Name": "Light",
+                        "Active": true,
+                        "Static": false,
+                        "ActiveHierarchy": true,
+                        "RootBoneId": 0,
+                        "Mask": 0,
+                        "Components": [
+                            {
+                                "Type": "Transform",
+                                "Id": 16139991150274622789,
+                                "Active": true,
+                                "Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "Scale": [
+                                    1.0,
+                                    1.0,
+                                    1.0
+                                ],
+                                "LocalEulerAngles": [
+                                    -0.0,
+                                    0.0,
+                                    -0.0
+                                ]
+                            },
+                            {
+                                "Type": "Light",
+                                "Id": 10940295342319452942,
+                                "Active": false,
+                                "LightType": 1,
+                                "Color": [
+                                    1.0,
+                                    1.0,
+                                    1.0
+                                ],
+                                "Intensity": 10.0,
+                                "Radius": 1.2000000476837159,
+                                "UseCustomFalloff": false,
+                                "FalloffExponent": 1.0,
+                                "InnerAngle": 0.2617993950843811,
+                                "OuterAngle": 0.5235987901687622
+                            }
+                        ],
+                        "Children": null
+                    }
+                ]
+            },
+            {
+                "Id": 18023275588375345054,
+                "Name": "Floor",
+                "Active": true,
+                "Static": false,
+                "ActiveHierarchy": true,
+                "RootBoneId": 0,
+                "Mask": 0,
+                "Components": [
+                    {
+                        "Type": "Transform",
+                        "Id": 14286438727003506146,
+                        "Active": true,
+                        "Position": [
+                            -12.829187393188477,
+                            0.10000000149011612,
+                            12.922187805175782
+                        ],
+                        "Rotation": [
+                            0.0,
+                            0.0,
+                            0.0,
+                            1.0
+                        ],
+                        "Scale": [
+                            0.004999999888241291,
+                            0.004999999888241291,
+                            0.004999999888241291
+                        ],
+                        "LocalEulerAngles": [
+                            -0.0,
+                            0.0,
+                            -0.0
+                        ]
+                    }
+                ],
+                "Children": [
+                    {
+                        "Id": 11435421712345410178,
+                        "Name": "Base",
+                        "Active": true,
+                        "Static": false,
+                        "ActiveHierarchy": true,
+                        "RootBoneId": 0,
+                        "Mask": 0,
+                        "Components": [
+                            {
+                                "Type": "Transform",
+                                "Id": 17612561848101592459,
+                                "Active": true,
+                                "Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "Scale": [
+                                    1.0,
+                                    1.0,
+                                    1.0
+                                ],
+                                "LocalEulerAngles": [
+                                    -0.0,
+                                    0.0,
+                                    -0.0
+                                ]
+                            },
+                            {
+                                "Type": "MeshRenderer",
+                                "Id": 16977747359825895526,
+                                "Active": true,
+                                "MeshID": 565187896708746887,
+                                "MaterialID": 7474379652010552095
+                            },
+                            {
+                                "Type": "BoundingBox",
+                                "Id": 5543832700931311208,
+                                "Active": true,
+                                "LocalBoundingBox": [
+                                    -40.650142669677737,
+                                    -42.938323974609378,
+                                    -4940.123046875,
+                                    4940.4892578125,
+                                    -15.8513822555542,
+                                    -18.5028076171875
+                                ]
+                            }
+                        ],
+                        "Children": null
+                    },
+                    {
+                        "Id": 8468612891485898416,
+                        "Name": "Planks",
+                        "Active": true,
+                        "Static": false,
+                        "ActiveHierarchy": true,
+                        "RootBoneId": 0,
+                        "Mask": 0,
+                        "Components": [
+                            {
+                                "Type": "Transform",
+                                "Id": 13922238331362377687,
+                                "Active": true,
+                                "Position": [
+                                    0.0,
+                                    0.0,
+                                    0.0
+                                ],
+                                "Rotation": [
+                                    0.0,
+                                    0.0,
+                                    0.0,
+                                    1.0
+                                ],
+                                "Scale": [
+                                    1.0,
+                                    1.0,
+                                    1.0
+                                ],
+                                "LocalEulerAngles": [
+                                    -0.0,
+                                    0.0,
+                                    -0.0
+                                ]
+                            },
+                            {
+                                "Type": "MeshRenderer",
+                                "Id": 8631618502785653343,
+                                "Active": true,
+                                "MeshID": 1332246080077846127,
+                                "MaterialID": 7474379652010552095
+                            },
+                            {
+                                "Type": "BoundingBox",
+                                "Id": 11052588163876829197,
+                                "Active": true,
+                                "LocalBoundingBox": [
+                                    -82.52242279052735,
+                                    -63.307151794433597,
+                                    -4958.263671875,
+                                    4956.6884765625,
+                                    7.684663772583008,
+                                    68.612060546875
+                                ]
+                            }
+                        ],
+                        "Children": null
                     }
                 ]
             }

--- a/Game/Assets/Shaders/trail.shader
+++ b/Game/Assets/Shaders/trail.shader
@@ -5,12 +5,13 @@ layout(location = 1) in vec2 vertexUV0;
 
 uniform mat4 proj;
 uniform mat4 view;
+uniform mat4 model;
 
 out vec2 uv0;
 
 void main()
 {
-	gl_Position = proj*view*vec4(vertexPosition.xyz, 1.0);
+	gl_Position = proj * view * model * vec4(vertexPosition.xyz, 1.0);
 	uv0 = vertexUV0;
 
 }
@@ -23,11 +24,16 @@ uniform sampler2D diffuseMap;
 uniform vec4 inputColor;
 uniform int hasDiffuse;
 
+uniform int flipX;
+uniform int flipY;
 
 out vec4 outColor;
 
 void main()
 {	
-	outColor = SRGBA(inputColor) * (hasDiffuse * SRGBA(texture2D(diffuseMap,  uv0 )) + (1 - hasDiffuse));
+	float u = flipX * (1 - uv0.x) + (1 - flipX) * uv0.x;
+	float v = flipY * (1 - uv0.y) + (1 - flipY) * uv0.y;
+
+	outColor = SRGBA(inputColor) * (hasDiffuse * SRGBA(texture2D(diffuseMap, vec2(u, v))) + (1 - hasDiffuse));
 }
 

--- a/Project/Source/Components/ComponentParticleSystem.cpp
+++ b/Project/Source/Components/ComponentParticleSystem.cpp
@@ -110,13 +110,16 @@
 
 // Trail
 #define JSON_TAG_HASTRAIL "HasTrail"
-#define JSON_TAG_TRAIL_TEXTURE_TEXTUREID "TextureTrailID"
-
-#define JSON_TAG_WIDTH "Width"
+#define JSON_TAG_TRAIL_RATIO "TrailRatio"
+#define JSON_TAG_TRAIL_WIDTH_RM "WidthRM"
+#define JSON_TAG_TRAIL_WIDTH "Width"
+#define JSON_TAG_TRAIL_QUADS_RM "TrailQuadsRM"
 #define JSON_TAG_TRAIL_QUADS "TrailQuads"
-#define JSON_TAG_TEXTURE_REPEATS "TextureRepeats"
-#define JSON_TAG_QUAD_LIFE "QuadLife"
-
+#define JSON_TAG_TRAIL_QUAD_LIFE_RM "QuadLifeRM"
+#define JSON_TAG_TRAIL_QUAD_LIFE "QuadLife"
+#define JSON_TAG_TRAIL_TEXTURE_TEXTUREID "TextureTrailID"
+#define JSON_TAG_TRAIL_FLIP_TEXTURE "FlipTrailTexture"
+#define JSON_TAG_TRAIL_TEXTURE_REPEATS "TextureRepeats"
 #define JSON_TAG_HAS_COLOR_OVER_TRAIL "HasColorOverTrail"
 #define JSON_TAG_NUMBER_COLORS_TRAIL "NumberColorsTrail"
 #define JSON_TAG_GRADIENT_COLORS_TRAIL "GradientColorsTrail"
@@ -130,13 +133,13 @@
 
 #define ITEM_SIZE 150
 
-static bool ImGuiRandomMenu(const char* name, float2& values, RandomMode& mode, float speed = 0.01f, float min = 0, float max = inf) {
+static bool ImGuiRandomMenu(const char* name, float2& values, RandomMode& mode, float speed = 0.01f, float min = 0, float max = inf, const char* format = "%.3f", ImGuiSliderFlags flags = 0) {
 	ImGui::PushID(name);
 	bool used = false;
 	if (mode == RandomMode::CONST) {
-		used = ImGui::DragFloat(name, &values[0], App->editor->dragSpeed2f, min, max);
+		used = ImGui::DragFloat(name, &values[0], App->editor->dragSpeed2f, min, max, format, flags);
 	} else if (mode == RandomMode::CONST_MULT) {
-		used = ImGui::DragFloat2(name, &values[0], App->editor->dragSpeed2f, min, max);
+		used = ImGui::DragFloat2(name, &values[0], App->editor->dragSpeed2f, min, max, format, flags);
 	}
 	if (used && values[0] > values[1]) {
 		values[1] = values[0];
@@ -459,13 +462,14 @@ void ComponentParticleSystem::OnEditorUpdate() {
 		}
 		if (hasTrail) {
 			ImGui::Indent();
-			ImGui::DragFloat("Witdh", &width, App->editor->dragSpeed2f, 0, inf);
-
-			ImGui::DragInt("Trail Quads", &trailQuads, 1.0f, 1, 50, "%d", ImGuiSliderFlags_AlwaysClamp);
-
-			ImGui::DragInt("Texture Repeats", &nTextures, 1.0f, 1, trailQuads, "%d", ImGuiSliderFlags_AlwaysClamp);
-
-			ImGui::DragFloat("Quad Life", &quadLife, App->editor->dragSpeed2f, 1, inf);
+			ImGui::DragFloat("Ratio", &trailRatio, App->editor->dragSpeed2f, 0, 1, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+			if (ImGuiRandomMenu("Width", width, widthRM, App->editor->dragSpeed2f, 0, inf)) {
+				for (Particle& particle : particles) {
+					particle.trail->width = ObtainRandomValueFloat(width, widthRM);
+				}
+			}
+			ImGuiRandomMenu("Num Quads (Length)", trailQuads, trailQuadsRM, 1.0f, 1, 50, "%.1f", ImGuiSliderFlags_AlwaysClamp);
+			ImGuiRandomMenu("Quad Life", quadLife, quadLifeRM, App->editor->dragSpeed2f, 1, inf);
 
 			ImGui::Checkbox("Color Over Trail", &colorOverTrail);
 			if (colorOverTrail) {
@@ -478,6 +482,20 @@ void ComponentParticleSystem::OnEditorUpdate() {
 
 			ImGui::NewLine();
 			ImGui::ResourceSlot<ResourceTexture>("texture", &textureTrailID);
+			ImGui::Text("Flip: ");
+			ImGui::SameLine();
+			if (ImGui::Checkbox("X##flip_trail", &flipTrailTexture[0])) {
+				for (Particle& particle : particles) {
+					particle.trail->flipTexture[0] = flipTrailTexture[0];
+				}
+			}
+			ImGui::SameLine();
+			if (ImGui::Checkbox("Y##flip_trail", &flipTrailTexture[1])) {
+				for (Particle& particle : particles) {
+					particle.trail->flipTexture[1] = flipTrailTexture[1];
+				}
+			}
+			ImGui::DragInt("Texture Repeats", &nTextures, 1.0f, 1, inf, "%d", ImGuiSliderFlags_AlwaysClamp);
 
 			ImGui::Unindent();
 		}
@@ -703,23 +721,36 @@ void ComponentParticleSystem::Load(JsonValue jComponent) {
 	//Trail
 	hasTrail = jComponent[JSON_TAG_HASTRAIL];
 
+	trailRatio = jComponent[JSON_TAG_TRAIL_RATIO];
+	widthRM = (RandomMode)(int) jComponent[JSON_TAG_TRAIL_WIDTH_RM];
+	JsonValue jWidth = jComponent[JSON_TAG_TRAIL_WIDTH];
+	width[0] = jWidth[0];
+	width[1] = jWidth[1];
+	trailQuadsRM = (RandomMode)(int) jComponent[JSON_TAG_TRAIL_QUADS_RM];
+	JsonValue jtrailQuads = jComponent[JSON_TAG_TRAIL_QUADS];
+	trailQuads[0] = jtrailQuads[0];
+	trailQuads[1] = jtrailQuads[1];
+	quadLifeRM = (RandomMode)(int) jComponent[JSON_TAG_TRAIL_QUAD_LIFE_RM];
+	JsonValue jQuadLife = jComponent[JSON_TAG_TRAIL_QUAD_LIFE];
+	quadLife[0] = jQuadLife[0];
+	quadLife[1] = jQuadLife[1];
+
 	textureTrailID = jComponent[JSON_TAG_TRAIL_TEXTURE_TEXTUREID];
 	if (textureTrailID != 0) {
 		App->resources->IncreaseReferenceCount(textureTrailID);
 	}
-
-	trailQuads = jComponent[JSON_TAG_TRAIL_QUADS];
-	quadLife = jComponent[JSON_TAG_QUAD_LIFE];
-	width = jComponent[JSON_TAG_WIDTH];
-	nTextures = jComponent[JSON_TAG_TEXTURE_REPEATS];
+	JsonValue jTrailFlip = jComponent[JSON_TAG_TRAIL_FLIP_TEXTURE];
+	flipTrailTexture[0] = jTrailFlip[0];
+	flipTrailTexture[1] = jTrailFlip[1];
+	nTextures = jComponent[JSON_TAG_TRAIL_TEXTURE_REPEATS];
 
 	colorOverTrail = jComponent[JSON_TAG_HAS_COLOR_OVER_TRAIL];
 	int trailNumberColors = jComponent[JSON_TAG_NUMBER_COLORS_TRAIL];
 	if (!gradientTrail) gradientTrail = new ImGradient();
 	gradientTrail->clearList();
-	JsonValue trailJColor = jComponent[JSON_TAG_GRADIENT_COLORS_TRAIL];
+	JsonValue jTrailColor = jComponent[JSON_TAG_GRADIENT_COLORS_TRAIL];
 	for (int i = 0; i < trailNumberColors; ++i) {
-		JsonValue jMark = trailJColor[i];
+		JsonValue jMark = jTrailColor[i];
 		gradientTrail->addMark(jMark[4], ImColor((float) jMark[0], (float) jMark[1], (float) jMark[2], (float) jMark[3]));
 	}
 
@@ -851,25 +882,39 @@ void ComponentParticleSystem::Save(JsonValue jComponent) const {
 
 	// Trail
 	jComponent[JSON_TAG_HASTRAIL] = hasTrail;
-	jComponent[JSON_TAG_TRAIL_TEXTURE_TEXTUREID] = textureTrailID;
-	jComponent[JSON_TAG_TRAIL_QUADS] = trailQuads;
 
-	jComponent[JSON_TAG_WIDTH] = width;
-	jComponent[JSON_TAG_TEXTURE_REPEATS] = nTextures;
-	jComponent[JSON_TAG_QUAD_LIFE] = quadLife;
+	jComponent[JSON_TAG_TRAIL_RATIO] = trailRatio;
+	jComponent[JSON_TAG_TRAIL_WIDTH_RM] = (int) widthRM;
+	JsonValue jWidth = jComponent[JSON_TAG_TRAIL_WIDTH];
+	jWidth[0] = width[0];
+	jWidth[1] = width[1];
+	jComponent[JSON_TAG_TRAIL_QUADS_RM] = (int) trailQuadsRM;
+	JsonValue jTrailQuads = jComponent[JSON_TAG_TRAIL_QUADS];
+	jTrailQuads[0] = trailQuads[0];
+	jTrailQuads[1] = trailQuads[1];
+	jComponent[JSON_TAG_TRAIL_QUAD_LIFE_RM] = (int) quadLifeRM;
+	JsonValue jQuadLife = jComponent[JSON_TAG_TRAIL_QUAD_LIFE];
+	jQuadLife[0] = quadLife[0];
+	jQuadLife[1] = quadLife[1];
+
+	jComponent[JSON_TAG_TRAIL_TEXTURE_TEXTUREID] = textureTrailID;
+	JsonValue jTrailFlip = jComponent[JSON_TAG_TRAIL_FLIP_TEXTURE];
+	jTrailFlip[0] = flipTrailTexture[0];
+	jTrailFlip[1] = flipTrailTexture[1];
+	jComponent[JSON_TAG_TRAIL_TEXTURE_REPEATS] = nTextures;
 
 	jComponent[JSON_TAG_HAS_COLOR_OVER_TRAIL] = colorOverTrail;
 	int trailColor = 0;
-	JsonValue trailJColor = jComponent[JSON_TAG_GRADIENT_COLORS_TRAIL];
+	JsonValue jTrailColor = jComponent[JSON_TAG_GRADIENT_COLORS_TRAIL];
 	for (ImGradientMark* mark : gradientTrail->getMarks()) {
-		JsonValue jMask = jColor[trailJColor];
+		JsonValue jMask = jTrailColor[trailColor];
 		jMask[0] = mark->color[0];
 		jMask[1] = mark->color[1];
 		jMask[2] = mark->color[2];
 		jMask[3] = mark->color[3];
 		jMask[4] = mark->position;
 
-		color++;
+		trailColor++;
 	}
 	jComponent[JSON_TAG_NUMBER_COLORS_TRAIL] = gradientTrail->getMarks().size();
 
@@ -918,7 +963,7 @@ void ComponentParticleSystem::SpawnParticleUnit() {
 		InitParticleSpeed(currentParticle);
 		InitParticleLife(currentParticle);
 		InitParticleAnimationTexture(currentParticle);
-		if (hasTrail) {
+		if (hasTrail && IsProbably(trailRatio)) {
 			InitParticleTrail(currentParticle);
 		}
 		currentParticle->emitterPosition = GetOwner().GetComponent<ComponentTransform>()->GetGlobalPosition();
@@ -1030,15 +1075,19 @@ void ComponentParticleSystem::InitParticleAnimationTexture(Particle* currentPart
 void ComponentParticleSystem::InitParticleTrail(Particle* currentParticle) {
 	currentParticle->trail = new Trail();
 	currentParticle->trail->Init();
-	currentParticle->trail->width = width;
-	currentParticle->trail->trailQuads = trailQuads;
-	currentParticle->trail->nTextures = nTextures;
-	currentParticle->trail->quadLife = quadLife;
+	currentParticle->trail->width = ObtainRandomValueFloat(width, widthRM);
+	currentParticle->trail->trailQuads = ObtainRandomValueFloat(trailQuads, trailQuadsRM);
+	currentParticle->trail->quadLife = ObtainRandomValueFloat(quadLife, quadLifeRM);
+
+	currentParticle->trail->textureID = textureTrailID;
+	currentParticle->trail->flipTexture[0] = flipTrailTexture[0];
+	currentParticle->trail->flipTexture[1] = flipTrailTexture[1];
+	currentParticle->trail->nTextures = (nTextures > currentParticle->trail->trailQuads ? currentParticle->trail->trailQuads : nTextures);
+
+	currentParticle->trail->colorOverTrail = colorOverTrail;
 	currentParticle->trail->gradient = gradientTrail;
 	currentParticle->trail->draggingGradient = draggingGradientTrail;
 	currentParticle->trail->selectedGradient = selectedGradientTrail;
-	currentParticle->trail->colorOverTrail = colorOverTrail;
-	currentParticle->trail->textureID = textureTrailID;
 }
 
 void ComponentParticleSystem::InitStartDelay() {
@@ -1399,7 +1448,7 @@ void ComponentParticleSystem::Draw() {
 			glDepthMask(GL_TRUE);
 
 			if (hasTrail) {
-				currentParticle.trail->Draw();
+				currentParticle.trail->Draw(float4x4::identity);
 			}
 			if (App->renderer->drawColliders) {
 				dd::sphere(currentParticle.position, dd::colors::LawnGreen, currentParticle.radius);

--- a/Project/Source/Components/ComponentParticleSystem.cpp
+++ b/Project/Source/Components/ComponentParticleSystem.cpp
@@ -465,7 +465,9 @@ void ComponentParticleSystem::OnEditorUpdate() {
 			ImGui::DragFloat("Ratio", &trailRatio, App->editor->dragSpeed2f, 0, 1, "%.2f", ImGuiSliderFlags_AlwaysClamp);
 			if (ImGuiRandomMenu("Width", width, widthRM, App->editor->dragSpeed2f, 0, inf)) {
 				for (Particle& particle : particles) {
-					particle.trail->width = ObtainRandomValueFloat(width, widthRM);
+					if (particle.trail != nullptr) {
+						particle.trail->width = ObtainRandomValueFloat(width, widthRM);
+					}
 				}
 			}
 			ImGuiRandomMenu("Num Quads (Length)", trailQuads, trailQuadsRM, 1.0f, 1, 50, "%.1f", ImGuiSliderFlags_AlwaysClamp);
@@ -486,13 +488,17 @@ void ComponentParticleSystem::OnEditorUpdate() {
 			ImGui::SameLine();
 			if (ImGui::Checkbox("X##flip_trail", &flipTrailTexture[0])) {
 				for (Particle& particle : particles) {
-					particle.trail->flipTexture[0] = flipTrailTexture[0];
+					if (particle.trail != nullptr) {
+						particle.trail->flipTexture[0] = flipTrailTexture[0];
+					}
 				}
 			}
 			ImGui::SameLine();
 			if (ImGui::Checkbox("Y##flip_trail", &flipTrailTexture[1])) {
 				for (Particle& particle : particles) {
-					particle.trail->flipTexture[1] = flipTrailTexture[1];
+					if (particle.trail != nullptr) {
+						particle.trail->flipTexture[1] = flipTrailTexture[1];
+					}
 				}
 			}
 			ImGui::DragInt("Texture Repeats", &nTextures, 1.0f, 1, inf, "%d", ImGuiSliderFlags_AlwaysClamp);
@@ -1169,7 +1175,7 @@ void ComponentParticleSystem::Update() {
 				if (!isRandomFrame) {
 					currentParticle.currentFrame += currentParticle.animationSpeed * App->time->GetDeltaTimeOrRealDeltaTime();
 				}
-				if (hasTrail) {
+				if (currentParticle.trail != nullptr) {
 					UpdateTrail(&currentParticle);
 				}
 
@@ -1447,7 +1453,7 @@ void ComponentParticleSystem::Draw() {
 			glDisable(GL_BLEND);
 			glDepthMask(GL_TRUE);
 
-			if (hasTrail) {
+			if (currentParticle.trail != nullptr) {
 				currentParticle.trail->Draw(float4x4::identity);
 			}
 			if (App->renderer->drawColliders) {

--- a/Project/Source/Components/ComponentParticleSystem.cpp
+++ b/Project/Source/Components/ComponentParticleSystem.cpp
@@ -131,6 +131,21 @@
 #define JSON_TAG_SUB_EMMITERS_EMITTER_TYPE "EmitterType"
 #define JSON_TAG_SUB_EMITTERS_EMIT_PROB "EmitProbability"
 
+// Lights
+#define JSON_TAG_HAS_LIGHTS "HasLights"
+#define JSON_TAG_LIGHT_GAMEOBJECT "LightGameObjectUID"
+#define JSON_TAG_LIGHTS_RATIO "LightsRatio"
+#define JSON_TAG_LIGHTS_OFFSET "LightsOffset"
+#define JSON_TAG_LIGHTS_INTENSITY_MULTIPLIER_RM "IntensityMultiplierRM"
+#define JSON_TAG_LIGHTS_INTENSITY_MULTIPLIER "IntensityMultiplier"
+#define JSON_TAG_LIGHTS_RANGE_MULTIPLIER_RM "RangeMultiplierRM"
+#define JSON_TAG_LIGHTS_RANGE_MULTIPLIER "RangeMultiplier"
+#define JSON_TAG_LIGHTS_USE_PARTICLE_COLOR "UseParticleColor"
+#define JSON_TAG_LIGHTS_USE_CUSTOM_COLOR "UseCustomColor"
+#define JSON_TAG_LIGHTS_NUMBER_COLORS "NumberColorsLights"
+#define JSON_TAG_LIGHTS_GRADIENT_COLORS "GradientColorsLights"
+#define JSON_TAG_LIGHTS_MAX_LIGHTS "MaxLights"
+
 #define ITEM_SIZE 150
 
 static bool ImGuiRandomMenu(const char* name, float2& values, RandomMode& mode, float speed = 0.01f, float min = 0, float max = inf, const char* format = "%.3f", ImGuiSliderFlags flags = 0) {
@@ -179,6 +194,7 @@ static bool IsProbably(float probablility) {
 ComponentParticleSystem::~ComponentParticleSystem() {
 	RELEASE(gradient);
 	RELEASE(gradientTrail);
+	RELEASE(gradientLight);
 
 	UndertakerParticle(true);
 	for (SubEmitter* subEmitter : subEmitters) {
@@ -191,6 +207,7 @@ ComponentParticleSystem::~ComponentParticleSystem() {
 void ComponentParticleSystem::Init() {
 	if (!gradient) gradient = new ImGradient();
 	if (!gradientTrail) gradientTrail = new ImGradient();
+	if (!gradientLight) gradientLight = new ImGradient();
 	layer = WorldLayers(1 << layerIndex);
 	AllocateParticlesMemory();
 	isStarted = false;
@@ -212,6 +229,21 @@ void ComponentParticleSystem::Start() {
 				subEmitters.erase(subEmitters.begin() + pos);
 			}
 			pos += 1;
+		}
+	}
+	if (lightGameObjectUID != 0) {
+		GameObject* gameObject = App->scene->scene->GetGameObject(lightGameObjectUID);
+		if (gameObject != nullptr) {
+			ComponentLight* light = gameObject->GetComponent<ComponentLight>();
+			if (light == nullptr || light->lightType != LightType::POINT) {
+				lightGameObjectUID = 0;
+				lightComponent = nullptr;
+			} else {
+				lightComponent = light;
+			}
+		} else {
+			lightGameObjectUID = 0;
+			lightComponent = nullptr;
 		}
 	}
 }
@@ -577,6 +609,63 @@ void ComponentParticleSystem::OnEditorUpdate() {
 		}
 	}
 
+	// Lights
+	if (ImGui::CollapsingHeader("Lights")) {
+		ImGui::Checkbox("##lights", &hasLights);
+		if (hasLights) {
+			ImGui::Indent();
+			UID oldUID = lightGameObjectUID;
+			ImGui::GameObjectSlot("Point Light", &lightGameObjectUID);
+			if (oldUID != lightGameObjectUID) {
+				GameObject* gameObject = App->scene->scene->GetGameObject(lightGameObjectUID);
+				if (gameObject != nullptr) {
+					ComponentLight* light = gameObject->GetComponent<ComponentLight>();
+					if (light == nullptr || light->lightType != LightType::POINT) {
+						lightGameObjectUID = 0;
+						lightComponent = nullptr;
+					} else {
+						lightComponent = light;
+					}
+				} else {
+					lightGameObjectUID = 0;
+					lightComponent = nullptr;
+				}
+			}
+			ImGui::NewLine();
+			ImGui::DragFloat("Ratio##lights_ratio", &lightsRatio, App->editor->dragSpeed2f, 0, 1, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+			ImGuiRandomMenu("Intensity Multiplier", intensityMultiplier, intensityMultiplierRM, App->editor->dragSpeed2f, 0, 10, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+			ImGuiRandomMenu("Range Multiplier", rangeMultiplier, rangeMultiplierRM, App->editor->dragSpeed2f, 0, 10, "%.2f", ImGuiSliderFlags_AlwaysClamp);
+			if (ImGui::Checkbox("Use Particle Color", &useParticleColor)) {
+				if (useParticleColor && useCustomColor) {
+					useCustomColor = false;
+				}
+			}
+			ImGui::SameLine();
+			ImGui::Spacing();
+			ImGui::SameLine();
+			if (ImGui::Checkbox("Use Custom Color", &useCustomColor)) {
+				if (useCustomColor && useParticleColor) {
+					useParticleColor = false;
+				}
+			}
+			if (useCustomColor) {
+				ImGui::PopItemWidth();
+				ImGui::PushItemWidth(200);
+				ImGui::GradientEditor(gradientLight, draggingGradientLight, selectedGradientLight);
+				ImGui::PopItemWidth();
+				ImGui::PushItemWidth(ITEM_SIZE);
+				ImGui::NewLine();
+			}
+			ImGui::DragInt("Max Lights", &maxLights, 1.0f, 0, 10, "%d", ImGuiSliderFlags_AlwaysClamp);
+
+			ImGui::NewLine();
+			ImGui::SetNextItemWidth(200);
+			ImGui::DragFloat3("Local Offset (X, Y, Z)", lightOffset.ptr(), App->editor->dragSpeed2f, inf, inf, "%.2f");
+
+			ImGui::Unindent();
+		}
+	}
+
 	ImGui::NewLine();
 
 	// Texture Preview
@@ -773,6 +862,33 @@ void ComponentParticleSystem::Load(JsonValue jComponent) {
 		subEmitters.push_back(subEmitter);
 	}
 
+	// Lights
+	hasLights = jComponent[JSON_TAG_HAS_LIGHTS];
+	lightGameObjectUID = jComponent[JSON_TAG_LIGHT_GAMEOBJECT];
+
+	lightsRatio = jComponent[JSON_TAG_LIGHTS_RATIO];
+	JsonValue jLightOffset = jComponent[JSON_TAG_LIGHTS_OFFSET];
+	lightOffset.Set(jLightOffset[0], jLightOffset[1], jLightOffset[2]);
+	intensityMultiplierRM = (RandomMode)(int) jComponent[JSON_TAG_LIGHTS_INTENSITY_MULTIPLIER_RM];
+	JsonValue jIntensityMultiplier = jComponent[JSON_TAG_LIGHTS_INTENSITY_MULTIPLIER];
+	intensityMultiplier.Set(jIntensityMultiplier[0], jIntensityMultiplier[1]);
+	rangeMultiplierRM = (RandomMode)(int) jComponent[JSON_TAG_LIGHTS_RANGE_MULTIPLIER_RM];
+	JsonValue jRangeMultiplier = jComponent[JSON_TAG_LIGHTS_RANGE_MULTIPLIER];
+	rangeMultiplier.Set(jRangeMultiplier[0], jRangeMultiplier[1]);
+
+	useParticleColor = jComponent[JSON_TAG_LIGHTS_USE_PARTICLE_COLOR];
+	useCustomColor = jComponent[JSON_TAG_LIGHTS_USE_CUSTOM_COLOR];
+	int lightsNumberColors = jComponent[JSON_TAG_LIGHTS_NUMBER_COLORS];
+	if (!gradientLight) gradientLight = new ImGradient();
+	gradientLight->clearList();
+	JsonValue jLightColor = jComponent[JSON_TAG_LIGHTS_GRADIENT_COLORS];
+	for (int i = 0; i < lightsNumberColors; ++i) {
+		JsonValue jMark = jLightColor[i];
+		gradientLight->addMark(jMark[4], ImColor((float) jMark[0], (float) jMark[1], (float) jMark[2], (float) jMark[3]));
+	}
+
+	maxLights = jComponent[JSON_TAG_LIGHTS_MAX_LIGHTS];
+
 	AllocateParticlesMemory();
 }
 
@@ -937,9 +1053,48 @@ void ComponentParticleSystem::Save(JsonValue jComponent) const {
 		num += 1;
 	}
 	jComponent[JSON_TAG_SUB_EMITTERS_NUMBER] = num;
+
+	// Lights
+	jComponent[JSON_TAG_HAS_LIGHTS] = hasLights;
+	jComponent[JSON_TAG_LIGHT_GAMEOBJECT] = lightGameObjectUID;
+
+	jComponent[JSON_TAG_LIGHTS_RATIO] = lightsRatio;
+	JsonValue jLightOffset = jComponent[JSON_TAG_LIGHTS_OFFSET];
+	jLightOffset[0] = lightOffset[0];
+	jLightOffset[1] = lightOffset[1];
+	jLightOffset[2] = lightOffset[2];
+	jComponent[JSON_TAG_LIGHTS_INTENSITY_MULTIPLIER_RM] = (int) intensityMultiplierRM;
+	JsonValue jIntensityMultiplier = jComponent[JSON_TAG_LIGHTS_INTENSITY_MULTIPLIER];
+	jIntensityMultiplier[0] = intensityMultiplier[0];
+	jIntensityMultiplier[1] = intensityMultiplier[1];
+	jComponent[JSON_TAG_LIGHTS_RANGE_MULTIPLIER_RM] = (int) rangeMultiplierRM;
+	JsonValue jRangeMultiplier = jComponent[JSON_TAG_LIGHTS_RANGE_MULTIPLIER];
+	jRangeMultiplier[0] = rangeMultiplier[0];
+	jRangeMultiplier[1] = rangeMultiplier[1];
+
+	jComponent[JSON_TAG_LIGHTS_USE_PARTICLE_COLOR] = useParticleColor;
+	jComponent[JSON_TAG_LIGHTS_USE_CUSTOM_COLOR] = useCustomColor;
+	int lightsColor = 0;
+	JsonValue jLightColor = jComponent[JSON_TAG_LIGHTS_GRADIENT_COLORS];
+	for (ImGradientMark* mark : gradientLight->getMarks()) {
+		JsonValue jMask = jLightColor[lightsColor];
+		jMask[0] = mark->color[0];
+		jMask[1] = mark->color[1];
+		jMask[2] = mark->color[2];
+		jMask[3] = mark->color[3];
+		jMask[4] = mark->position;
+
+		lightsColor++;
+	}
+	jComponent[JSON_TAG_LIGHTS_NUMBER_COLORS] = gradientLight->getMarks().size();
+
+	jComponent[JSON_TAG_LIGHTS_MAX_LIGHTS] = maxLights;
 }
 
 void ComponentParticleSystem::AllocateParticlesMemory() {
+	if (isPlaying) {
+		Restart();
+	}
 	particles.Allocate(maxParticles);
 }
 
@@ -981,6 +1136,12 @@ void ComponentParticleSystem::SpawnParticleUnit() {
 			App->physics->CreateParticleRigidbody(currentParticle);
 		}
 		InitSubEmitter(currentParticle, SubEmitterType::BIRTH);
+
+		if (hasLights && IsProbably(lightsRatio)) {
+			if (lightsSpawned < maxLights) {
+				InitLight(currentParticle);
+			}
+		}
 	}
 }
 
@@ -1082,7 +1243,7 @@ void ComponentParticleSystem::InitParticleTrail(Particle* currentParticle) {
 	currentParticle->trail = new Trail();
 	currentParticle->trail->Init();
 	currentParticle->trail->width = ObtainRandomValueFloat(width, widthRM);
-	currentParticle->trail->trailQuads = ObtainRandomValueFloat(trailQuads, trailQuadsRM);
+	currentParticle->trail->trailQuads = (int) ObtainRandomValueFloat(trailQuads, trailQuadsRM);
 	currentParticle->trail->quadLife = ObtainRandomValueFloat(quadLife, quadLifeRM);
 
 	currentParticle->trail->textureID = textureTrailID;
@@ -1145,6 +1306,48 @@ void ComponentParticleSystem::InitSubEmitter(Particle* currentParticle, SubEmitt
 	}
 }
 
+void ComponentParticleSystem::InitLight(Particle* currentParticle) {
+	if (lightComponent == nullptr) return;
+
+	GameObject& parent = GetOwner();
+	Scene* scene = parent.scene;
+	UID gameObjectId = GenerateUID();
+	GameObject* newGameObject = scene->gameObjects.Obtain(gameObjectId);
+	newGameObject->scene = scene;
+	newGameObject->id = gameObjectId;
+	newGameObject->name = "Light (Temp)";
+	newGameObject->SetParent(&parent);
+	ComponentTransform* transform = newGameObject->CreateComponent<ComponentTransform>();
+	ComponentTransform* transformPS = GetOwner().GetComponent<ComponentTransform>();
+	float3 globalOffset = transformPS->GetGlobalMatrix().RotatePart() * lightOffset;
+	transform->SetGlobalPosition(currentParticle->position + globalOffset);
+	transform->SetGlobalRotation(float3::zero);
+	transform->SetGlobalScale(float3::one);
+	newGameObject->Init();
+
+	ComponentLight* newLight = newGameObject->CreateComponent<ComponentLight>();
+	rapidjson::Document resourceMetaDocument;
+	JsonValue jResourceMeta(resourceMetaDocument, resourceMetaDocument);
+	lightComponent->Save(jResourceMeta);
+	newLight->Load(jResourceMeta);
+	newLight->Enable();
+	newLight->lightType = LightType::POINT;
+	newLight->intensity *= ObtainRandomValueFloat(intensityMultiplier, intensityMultiplierRM);
+	newLight->radius *= ObtainRandomValueFloat(rangeMultiplier, rangeMultiplierRM);
+
+	if (useParticleColor && colorOverLifetime) {
+		float4 color = float4::one;
+		gradient->getColorAt(0.0f, color.ptr());
+		newLight->color = float3(color.x, color.y, color.z);
+	} else if (useCustomColor) {
+		float4 color = float4::one;
+		gradientLight->getColorAt(0.0f, color.ptr());
+		newLight->color = float3(color.x, color.y, color.z);
+	}
+	currentParticle->lightGO = newGameObject;
+	lightsSpawned++;
+}
+
 void ComponentParticleSystem::Update() {
 	if (!isStarted && App->time->HasGameStarted() && playOnAwake) {
 		Play();
@@ -1186,6 +1389,10 @@ void ComponentParticleSystem::Update() {
 
 				if (currentParticle.hasCollided) {
 					InitSubEmitter(&currentParticle, SubEmitterType::COLLISION);
+				}
+
+				if (currentParticle.lightGO != nullptr) {
+					UpdateLight(&currentParticle);
 				}
 			}
 		}
@@ -1308,6 +1515,40 @@ void ComponentParticleSystem::UpdateSubEmitters() {
 	}
 }
 
+void ComponentParticleSystem::UpdateLight(Particle* currentParticle) {
+	if (lightComponent && lightComponent->lightType != LightType::POINT) {
+		lightGameObjectUID = 0;
+		lightComponent = nullptr;
+	}
+
+	if (currentParticle->lightGO && (lightGameObjectUID == 0 || !hasLights)) {
+		App->scene->DestroyGameObjectDeferred(currentParticle->lightGO);
+		lightsSpawned--;
+	}
+
+	if (currentParticle->lightGO == nullptr) return;
+	ComponentLight* light = currentParticle->lightGO->GetComponent<ComponentLight>();
+	if (light == nullptr) return;
+
+	float3 position = currentParticle->position;
+	ComponentTransform* transform = currentParticle->lightGO->GetComponent<ComponentTransform>();
+	ComponentTransform* transformPS = GetOwner().GetComponent<ComponentTransform>();
+	float3 globalOffset = transformPS->GetGlobalMatrix().RotatePart() * lightOffset;
+	transform->SetGlobalPosition(currentParticle->position + globalOffset);
+
+	if (useParticleColor && colorOverLifetime) {
+		float4 color = float4::one;
+		float factor = 1 - currentParticle->life / currentParticle->initialLife;
+		gradient->getColorAt(factor, color.ptr());
+		light->color = float3(color.x, color.y, color.z);
+	} else if (useCustomColor) {
+		float4 color = float4::one;
+		float factor = 1 - currentParticle->life / currentParticle->initialLife;
+		gradientLight->getColorAt(factor, color.ptr());
+		light->color = float3(color.x, color.y, color.z);
+	}
+}
+
 void ComponentParticleSystem::KillParticle(Particle* currentParticle) {
 	currentParticle->life = -1;
 }
@@ -1324,6 +1565,12 @@ void ComponentParticleSystem::UndertakerParticle(bool force) {
 			RELEASE(currentParticle->motionState);
 		}
 		RELEASE(currentParticle->trail);
+
+		if (currentParticle->lightGO != nullptr) {
+			if (App->editor->selectedGameObject == currentParticle->lightGO) App->editor->selectedGameObject = nullptr;
+			App->scene->DestroyGameObjectDeferred(currentParticle->lightGO);
+			lightsSpawned--;
+		}
 		particles.Release(currentParticle);
 	}
 	deadParticles.clear();
@@ -1511,6 +1758,7 @@ void ComponentParticleSystem::Restart() {
 void ComponentParticleSystem::Stop() {
 	UndertakerParticle(true);
 	isPlaying = false;
+	lightsSpawned = 0;
 }
 
 void ComponentParticleSystem::PlayChildParticles() {
@@ -1676,8 +1924,13 @@ bool ComponentParticleSystem::GetCollision() const {
 }
 
 // Sub Emitter
-bool ComponentParticleSystem::GetIsSubEmitter() {
+bool ComponentParticleSystem::GetIsSubEmitter() const {
 	return isSubEmitter;
+}
+
+// Lights
+bool ComponentParticleSystem::GetHasLights() const {
+	return hasLights;
 }
 
 // ----- SETTERS -----
@@ -1811,4 +2064,9 @@ void ComponentParticleSystem::SetCollision(bool _collision) {
 // Sub Emitter
 void ComponentParticleSystem::SetIsSubEmitter(bool _isSubEmitter) {
 	isSubEmitter = _isSubEmitter;
+}
+
+// Lights
+void ComponentParticleSystem::SetHasLights(bool _hasLights) {
+	hasLights = _hasLights;
 }

--- a/Project/Source/Components/ComponentParticleSystem.h
+++ b/Project/Source/Components/ComponentParticleSystem.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 class ComponentTransform;
+class ComponentLight;
 class ParticleModule;
 class btRigidBody;
 class ParticleMotionState;
@@ -93,7 +94,12 @@ public:
 		ComponentParticleSystem* emitter = nullptr;
 		Collider col {this, typeid(Particle)};
 		float radius = 0;
+
+		// Trail
 		Trail* trail = nullptr;
+
+		// Light
+		GameObject* lightGO = nullptr;
 	};
 
 	struct SubEmitter {
@@ -129,6 +135,7 @@ public:
 	void InitStartDelay();
 	void InitStartRate();
 	void InitSubEmitter(Particle* currentParticle, SubEmitterType subEmitterType);
+	void InitLight(Particle* currentParticle);
 
 	TESSERACT_ENGINE_API void UpdatePosition(Particle* currentParticle);
 	void UpdateRotation(Particle* currentParticle);
@@ -137,6 +144,7 @@ public:
 	void UpdateTrail(Particle* currentParticle);
 	void UpdateGravityDirection(Particle* currentParticle);
 	void UpdateSubEmitters();
+	void UpdateLight(Particle* currentParticle);
 
 	TESSERACT_ENGINE_API void KillParticle(Particle* currentParticle);
 	void UndertakerParticle(bool force = false);
@@ -208,7 +216,10 @@ public:
 	TESSERACT_ENGINE_API bool GetCollision() const;
 
 	// Sub Emitter
-	TESSERACT_ENGINE_API bool GetIsSubEmitter();
+	TESSERACT_ENGINE_API bool GetIsSubEmitter() const;
+
+	// Lights
+	TESSERACT_ENGINE_API bool GetHasLights() const;
 
 	// ----- SETTERS -----
 
@@ -269,6 +280,9 @@ public:
 	// Sub Emitter
 	TESSERACT_ENGINE_API void SetIsSubEmitter(bool _isEmitter);
 
+	// Lights
+	TESSERACT_ENGINE_API void SetHasLights(bool _hasLights);
+
 public:
 	WorldLayers layer = (WorldLayers)(1 << 20); // = WorldLayers::EVERYHTING
 	int layerIndex = 5;
@@ -286,6 +300,7 @@ private:
 	float restDelayTime = 0.f;
 	float restParticlesPerSecond = 0.0f;
 	float particlesCurrentFrame = 0;
+	float lightsSpawned = 0;
 	std::vector<GameObject*> subEmittersGO;
 
 	// Gizmo
@@ -388,4 +403,21 @@ private:
 	// Sub Emitter
 	bool isSubEmitter = false;
 	std::vector<SubEmitter*> subEmitters;
+
+	// Lights
+	bool hasLights = false;
+	UID lightGameObjectUID = 0;
+	ComponentLight* lightComponent;
+	float lightsRatio = 1;
+	float3 lightOffset = float3::zero;
+	RandomMode intensityMultiplierRM = RandomMode::CONST;
+	float2 intensityMultiplier = {1.0f, 1.0f};
+	RandomMode rangeMultiplierRM = RandomMode::CONST;
+	float2 rangeMultiplier = {1.0f, 1.0f};
+	bool useParticleColor = false;
+	bool useCustomColor = false;
+	ImGradient* gradientLight = nullptr;
+	ImGradientMark* draggingGradientLight = nullptr;
+	ImGradientMark* selectedGradientLight = nullptr;
+	int maxLights = 0;
 };

--- a/Project/Source/Components/ComponentParticleSystem.h
+++ b/Project/Source/Components/ComponentParticleSystem.h
@@ -367,17 +367,20 @@ private:
 
 	// Trail
 	bool hasTrail = false;
+	float trailRatio = 1;
 
+	RandomMode widthRM = RandomMode::CONST;
+	float2 width = {0.1f, 0.1f};
+	RandomMode trailQuadsRM = RandomMode::CONST;
+	float2 trailQuads = {50.0f, 50.0f};
+	RandomMode quadLifeRM = RandomMode::CONST;
+	float2 quadLife = {10.0f, 10.f};
+
+	UID textureTrailID = 0;
+	bool flipTrailTexture[2] = {false, false};
 	int nTextures = 1;
-	int trailQuads = 50;
-
-	float nRepeats = 1;
-	float width = 0.1f;
-	float quadLife = 10.0f;
 
 	bool colorOverTrail = false;
-	UID textureTrailID = 0;
-
 	ImGradient* gradientTrail = nullptr;
 	ImGradientMark* draggingGradientTrail = nullptr;
 	ImGradientMark* selectedGradientTrail = nullptr;

--- a/Project/Source/Components/ComponentTrail.cpp
+++ b/Project/Source/Components/ComponentTrail.cpp
@@ -19,27 +19,34 @@
 
 #include "Utils/Leaks.h"
 
-#define JSON_TAG_TEXTURE_TEXTUREID "TextureId"
-#define JSON_TAG_MAXVERTICES "MaxVertices"
+#define JSON_TAG_IS_RENDERING "IsRendering"
 
 #define JSON_TAG_WIDTH "Width"
 #define JSON_TAG_TRAIL_QUADS "TrailQuads"
-#define JSON_TAG_TEXTURE_REPEATS "TextureRepeats"
 #define JSON_TAG_QUAD_LIFE "QuadLife"
-#define JSON_TAG_IS_RENDERING "IsRendering"
 
 #define JSON_TAG_HAS_COLOR_OVER_TRAIL "HasColorOverTrail"
 #define JSON_TAG_GRADIENT_COLOR "GradientColor"
 #define JSON_TAG_NUMBER_COLORS "NumColors"
 
+#define JSON_TAG_TEXTURE_TEXTUREID "TextureId"
+#define JSON_TAG_FLIP_TEXTURE "FlipTexture"
+#define JSON_TAG_TEXTURE_REPEATS "TextureRepeats"
+#define JSON_TAG_MAXVERTICES "MaxVertices"
+
 ComponentTrail::~ComponentTrail() {
 	RELEASE(trail);
+	RELEASE(gradient);
 }
 
 void ComponentTrail::Init() {
+	if (!gradient) gradient = new ImGradient();
 	if (!trail) trail = new Trail();
 	trail->Init();
 	trail->mainPosition = &GetOwner().GetComponent<ComponentTransform>()->GetPosition();
+	trail->gradient = gradient;
+	trail->draggingGradient = draggingGradient;
+	trail->selectedGradient = selectedGradient;
 }
 
 void ComponentTrail::Update() {
@@ -53,37 +60,44 @@ void ComponentTrail::OnEditorUpdate() {
 
 void ComponentTrail::Load(JsonValue jComponent) {
 	if (!trail) trail = new Trail();
+
+	trail->isRendering = jComponent[JSON_TAG_IS_RENDERING];
+	trail->width = jComponent[JSON_TAG_WIDTH];
+	trail->trailQuads = jComponent[JSON_TAG_TRAIL_QUADS];
+	trail->quadLife = jComponent[JSON_TAG_QUAD_LIFE];
+
+	trail->colorOverTrail = jComponent[JSON_TAG_HAS_COLOR_OVER_TRAIL];
+	int numberColors = jComponent[JSON_TAG_NUMBER_COLORS];
+	if (!gradient) gradient = new ImGradient();
+	gradient->clearList();
+	JsonValue jColor = jComponent[JSON_TAG_GRADIENT_COLOR];
+	for (int i = 0; i < numberColors; ++i) {
+		JsonValue jMark = jColor[i];
+		gradient->addMark(jMark[4], ImColor((float) jMark[0], (float) jMark[1], (float) jMark[2], (float) jMark[3]));
+	}
+	trail->gradient = gradient;
+	trail->draggingGradient = draggingGradient;
+	trail->selectedGradient = selectedGradient;
+
 	trail->textureID = jComponent[JSON_TAG_TEXTURE_TEXTUREID];
 	if (trail->textureID != 0) {
 		App->resources->IncreaseReferenceCount(trail->textureID);
 	}
-	trail->maxVertices = jComponent[JSON_TAG_MAXVERTICES];
-	trail->trailQuads = jComponent[JSON_TAG_TRAIL_QUADS];
-	trail->quadLife = jComponent[JSON_TAG_QUAD_LIFE];
-	trail->isRendering = jComponent[JSON_TAG_IS_RENDERING];
-	trail->width = jComponent[JSON_TAG_WIDTH];
+	JsonValue jFlip = jComponent[JSON_TAG_FLIP_TEXTURE];
+	trail->flipTexture[0] = jFlip[0];
+	trail->flipTexture[1] = jFlip[1];
 	trail->nTextures = jComponent[JSON_TAG_TEXTURE_REPEATS];
 
-	trail->colorOverTrail = jComponent[JSON_TAG_HAS_COLOR_OVER_TRAIL];
-	int numberColors = jComponent[JSON_TAG_NUMBER_COLORS];
-	if (!trail->gradient) trail->gradient = new ImGradient();
-	trail->gradient->clearList();
-	JsonValue jColor = jComponent[JSON_TAG_GRADIENT_COLOR];
-	for (int i = 0; i < numberColors; ++i) {
-		JsonValue jMark = jColor[i];
-		trail->gradient->addMark(jMark[4], ImColor((float) jMark[0], (float) jMark[1], (float) jMark[2], (float) jMark[3]));
-	}
+	trail->maxVertices = jComponent[JSON_TAG_MAXVERTICES];
 }
 
 void ComponentTrail::Save(JsonValue jComponent) const {
-	jComponent[JSON_TAG_TEXTURE_TEXTUREID] = trail->textureID;
-	jComponent[JSON_TAG_MAXVERTICES] = trail->maxVertices;
-	jComponent[JSON_TAG_TRAIL_QUADS] = trail->trailQuads;
+	jComponent[JSON_TAG_IS_RENDERING] = trail->isRendering;
 
 	jComponent[JSON_TAG_WIDTH] = trail->width;
-	jComponent[JSON_TAG_TEXTURE_REPEATS] = trail->nTextures;
+	jComponent[JSON_TAG_TRAIL_QUADS] = trail->trailQuads;
 	jComponent[JSON_TAG_QUAD_LIFE] = trail->quadLife;
-	jComponent[JSON_TAG_IS_RENDERING] = trail->isRendering;
+
 	// Color
 	jComponent[JSON_TAG_HAS_COLOR_OVER_TRAIL] = trail->colorOverTrail;
 	int color = 0;
@@ -99,9 +113,19 @@ void ComponentTrail::Save(JsonValue jComponent) const {
 		color++;
 	}
 	jComponent[JSON_TAG_NUMBER_COLORS] = trail->gradient->getMarks().size();
+
+	jComponent[JSON_TAG_TEXTURE_TEXTUREID] = trail->textureID;
+	JsonValue jFlip = jComponent[JSON_TAG_FLIP_TEXTURE];
+	jFlip[0] = trail->flipTexture[0];
+	jFlip[1] = trail->flipTexture[1];
+	jComponent[JSON_TAG_TEXTURE_REPEATS] = trail->nTextures;
+
+	jComponent[JSON_TAG_MAXVERTICES] = trail->maxVertices;
 }
+
 void ComponentTrail::Draw() {
-	trail->Draw();
+	float4x4 modelMatrix = float4x4::identity;
+	trail->Draw(modelMatrix);
 }
 
 TESSERACT_ENGINE_API void ComponentTrail::Play() {

--- a/Project/Source/Components/ComponentTrail.h
+++ b/Project/Source/Components/ComponentTrail.h
@@ -32,6 +32,7 @@ public:
 
 public:
 	Trail* trail = nullptr;
+
 	// Color Settings
 	ImGradient* gradient = nullptr;
 	ImGradientMark* draggingGradient = nullptr;

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -351,18 +351,20 @@ ProgramBillboard::ProgramBillboard(unsigned program_)
 
 ProgramTrail::ProgramTrail(unsigned program_)
 	: Program(program_) {
-	//modelLocation = glGetUniformLocation(program, "model");
 	viewLocation = glGetUniformLocation(program, "view");
 	projLocation = glGetUniformLocation(program, "proj");
+	modelLocation = glGetUniformLocation(program, "model");
 
 	inputColorLocation = glGetUniformLocation(program, "inputColor");
 	hasDiffuseLocation = glGetUniformLocation(program, "hasDiffuse");
 	diffuseMap = glGetUniformLocation(program, "diffuseMap");
+
+	xFlipLocation = glGetUniformLocation(program, "flipX");
+	yFlipLocation = glGetUniformLocation(program, "flipY");
 }
 
-ProgramStandardDissolve::ProgramStandardDissolve(unsigned program) 
+ProgramStandardDissolve::ProgramStandardDissolve(unsigned program)
 	: ProgramStandardMetallic(program) {
-
 	scaleLocation = glGetUniformLocation(program, "dissolveScale");
 	thresholdLocation = glGetUniformLocation(program, "dissolveThreshold");
 	offsetLocation = glGetUniformLocation(program, "dissolveOffset");
@@ -371,16 +373,14 @@ ProgramStandardDissolve::ProgramStandardDissolve(unsigned program)
 
 ProgramUnlitDissolve::ProgramUnlitDissolve(unsigned program)
 	: ProgramUnlit(program) {
-
 	scaleLocation = glGetUniformLocation(program, "dissolveScale");
 	thresholdLocation = glGetUniformLocation(program, "dissolveThreshold");
 	offsetLocation = glGetUniformLocation(program, "dissolveOffset");
 	edgeSizeLocation = glGetUniformLocation(program, "edgeSize");
 }
 
-ProgramDepthPrepassDissolve::ProgramDepthPrepassDissolve(unsigned program) 
+ProgramDepthPrepassDissolve::ProgramDepthPrepassDissolve(unsigned program)
 	: ProgramDepthPrepass(program) {
-
 	scaleLocation = glGetUniformLocation(program, "dissolveScale");
 	thresholdLocation = glGetUniformLocation(program, "dissolveThreshold");
 	offsetLocation = glGetUniformLocation(program, "dissolveOffset");

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -373,10 +373,13 @@ struct ProgramTrail : Program {
 
 	int viewLocation = -1;
 	int projLocation = -1;
+	int modelLocation = -1;
 
 	int inputColorLocation = -1;
 	int hasDiffuseLocation = -1;
 	int diffuseMap = -1;
+	int xFlipLocation = -1;
+	int yFlipLocation = -1;
 };
 
 struct ProgramStandardDissolve : ProgramStandardMetallic {

--- a/Project/Source/Utils/Trail.cpp
+++ b/Project/Source/Utils/Trail.cpp
@@ -30,12 +30,7 @@
 #include <string>
 #include "Utils/Leaks.h"
 
-Trail::~Trail() {
-	RELEASE(gradient);
-}
-
 void Trail::Init() {
-	if (!gradient) gradient = new ImGradient();
 	glGenBuffers(1, &quadVBO);
 	EditTextureCoords();
 }
@@ -118,43 +113,52 @@ void Trail::OnEditorUpdate() {
 	if (ImGui::Checkbox("Render", &isRendering)) {
 		isStarted = false;
 	}
-	ImGui::DragFloat("Witdh", &width, App->editor->dragSpeed2f, 0, inf);
+	ImGui::DragFloat("Width", &width, App->editor->dragSpeed2f, 0, inf);
 	if (ImGui::DragInt("Trail Quads", &trailQuads, 1.0f, 1, 50, "%d", ImGuiSliderFlags_AlwaysClamp)) {
 		if (nTextures > trailQuads) nTextures = trailQuads;
 		DeleteQuads();
 	}
-	if (ImGui::DragInt("Texture Repeats", &nTextures, 1.0f, 1, trailQuads, "%d", ImGuiSliderFlags_AlwaysClamp)) {
-		DeleteQuads();
-		EditTextureCoords();
-	}
-
 	ImGui::DragFloat("Quad Life", &quadLife, App->editor->dragSpeed2f, 1, inf);
 
+	ImGui::NewLine();
 	ImGui::Checkbox("Color Over Trail", &colorOverTrail);
 	if (colorOverTrail) {
 		ImGui::GradientEditor(gradient, draggingGradient, selectedGradient);
 	}
 
+	ImGui::NewLine();
 	ImGui::ResourceSlot<ResourceTexture>("texture", &textureID);
-	ResourceTexture* textureResource = App->resources->GetResource<ResourceTexture>(textureID);
-	if (textureResource != nullptr) {
-		int width;
-		int height;
-		glGetTextureLevelParameteriv(textureResource->glTexture, 0, GL_TEXTURE_WIDTH, &width);
-		glGetTextureLevelParameteriv(textureResource->glTexture, 0, GL_TEXTURE_HEIGHT, &height);
+	ImGui::Text("Flip: ");
+	ImGui::SameLine();
+	ImGui::Checkbox("X", &flipTexture[0]);
+	ImGui::SameLine();
+	ImGui::Checkbox("Y", &flipTexture[1]);
 
-		ImGui::NewLine();
-		ImGui::Separator();
-		ImGui::TextColored(App->editor->titleColor, "Texture Preview");
-		ImGui::TextWrapped("Size:");
-		ImGui::SameLine();
-		ImGui::TextWrapped("%d x %d", width, height);
-		ImGui::Image((void*) textureResource->glTexture, ImVec2(200, 200));
-		ImGui::Separator();
+	if (ImGui::DragInt("Texture Repeats", &nTextures, 1.0f, 1, trailQuads, "%d", ImGuiSliderFlags_AlwaysClamp)) {
+		DeleteQuads();
+		EditTextureCoords();
 	}
+
+	ImGui::NewLine();
+	ImGui::Indent();
+	if (ImGui::CollapsingHeader("Texture Preview")) {
+		ResourceTexture* textureResource = App->resources->GetResource<ResourceTexture>(textureID);
+		if (textureResource != nullptr) {
+			int width;
+			int height;
+			glGetTextureLevelParameteriv(textureResource->glTexture, 0, GL_TEXTURE_WIDTH, &width);
+			glGetTextureLevelParameteriv(textureResource->glTexture, 0, GL_TEXTURE_HEIGHT, &height);
+
+			ImGui::TextWrapped("Size:");
+			ImGui::SameLine();
+			ImGui::TextWrapped("%d x %d", width, height);
+			ImGui::Image((void*) textureResource->glTexture, ImVec2(200, 200));
+		}
+	}
+	ImGui::Unindent();
 }
 
-void Trail::Draw() {
+void Trail::Draw(float4x4 modelMatrix) {
 	ProgramTrail* trailProgram = App->programs->trail;
 	if (!trailProgram) return;
 	unsigned glTexture = 0;
@@ -189,6 +193,7 @@ void Trail::Draw() {
 
 		glUniformMatrix4fv(trailProgram->viewLocation, 1, GL_TRUE, view->ptr());
 		glUniformMatrix4fv(trailProgram->projLocation, 1, GL_TRUE, proj->ptr());
+		glUniformMatrix4fv(trailProgram->modelLocation, 1, GL_TRUE, modelMatrix.ptr());
 
 		float4 color = float4::one;
 		if (colorOverTrail) {
@@ -199,6 +204,9 @@ void Trail::Draw() {
 		glUniform1i(trailProgram->diffuseMap, 0);
 		glUniform1i(trailProgram->hasDiffuseLocation, hasDiffuseMap);
 		glUniform4fv(trailProgram->inputColorLocation, 1, color.ptr());
+
+		glUniform1i(trailProgram->xFlipLocation, flipTexture[0] ? 1 : 0);
+		glUniform1i(trailProgram->yFlipLocation, flipTexture[1] ? 1 : 0);
 
 		glBindTexture(GL_TEXTURE_2D, glTexture);
 

--- a/Project/Source/Utils/Trail.h
+++ b/Project/Source/Utils/Trail.h
@@ -3,8 +3,7 @@
 #include "Utils/Pool.h"
 #include "Utils/UID.h"
 
-#include "Math/float4.h"
-#include "Math/float2.h"
+#include "Math/float3.h"
 #include "Math/float4x4.h"
 #include "Math/Quat.h"
 
@@ -22,13 +21,11 @@ public:
 		float life = 0.0f;
 	};
 
-	~Trail();
-
 	void Init();
 	void Update(float3 mPosition);
 	void OnEditorUpdate();
 
-	void Draw();
+	void Draw(float4x4 modelMatrix);
 	void InsertVertex(Quad* currentQuad, float3 vertex);
 	void InsertTextureCoords(Quad* currentQuad);
 	void SpawnQuad(Quad* currentQuad);
@@ -69,6 +66,8 @@ public:
 	float quadLife = 10.0f;
 
 	bool isRendering = true;
+
+	bool flipTexture[2] = {false, false};
 
 	// Color Settings
 	ImGradient* gradient = nullptr;


### PR DESCRIPTION
Note: This PR has to be merged after https://github.com/PenteractStudios/Tesseract/pull/413. Not necessary for the delivery of Tuesday.

![1b1e04bce78ea61abe4d4801c74860d1](https://user-images.githubusercontent.com/48628366/128627638-2efc23e3-621b-4b30-bf41-2179c99cf44d.gif)

Functionality:
- We can attach a Light game object to a PS to create Lights for each Particle. Only Point Lights are allowed. It works like SubEmitters, creating temp game objects and deleting them when a particle dies.
- We can apply some modifiers to the base light like intensity and range multiplier.
- Different color options (base light color, particle color, custom color) for the particle light
- Randomness to parameters
- Limit of 10 lights for each PS to avoid overkilling the Engine. This number could be reduced. TBD with @JaimeBea 
- Possibility to modify the local position of the Light related to the particle with an offset.

![Screenshot 2021-08-08 114042](https://user-images.githubusercontent.com/48628366/128627799-0b9d5e39-78d3-43b0-a5b7-a1f1bbeccdfc.png)


 