### PR TITLE
Fixed model import problems

### DIFF
--- a/Project/Source/FileSystem/ModelImporter.cpp
+++ b/Project/Source/FileSystem/ModelImporter.cpp
@@ -800,7 +800,10 @@ void ModelImporter::CacheBones(GameObject* node, std::unordered_map<std::string,
 
 void ModelImporter::SaveBones(GameObject* node, std::unordered_map<std::string, GameObject*>& goBones) {
 	for (ComponentMeshRenderer& meshRenderer : node->GetComponents<ComponentMeshRenderer>()) {
-		meshRenderer.goBones = goBones;
+		ResourceMesh* resourceMesh = App->resources->GetResource<ResourceMesh>(meshRenderer.meshId);
+		if (resourceMesh && resourceMesh->bones.size() > 0) {
+			meshRenderer.goBones = goBones;
+		}
 	}
 
 	for (GameObject* child : node->GetChildren()) {


### PR DESCRIPTION
It was assumed that all the meshes in an fbx would have the same bones. This would cause an error because the Gameobjects would have "bones" even if they didn't, and that caused some rendering problems!