### PR TITLE
Forward+ rendering

### DIFF
--- a/Game/Assets/Shaders/drawLightTiles.shader
+++ b/Game/Assets/Shaders/drawLightTiles.shader
@@ -1,0 +1,13 @@
+--- fragDrawLightTiles
+
+in vec2 uv;
+
+out vec4 color;
+
+void main() {
+	ivec2 tile = ivec2(gl_FragCoord.xy) / ivec2(LIGHT_TILE_SIZE, LIGHT_TILE_SIZE);
+	int index = tile.x + tile.y * tilesPerRow;
+	float pointRatio = float(lightTiles.data[index].numPoints) / float(POINT_LIGHTS);
+	float spotRatio = float(lightTiles.data[index].numSpots) / float(SPOT_LIGHTS);
+	color = vec4(vec3(pointRatio, spotRatio, 0.0), 1.0);
+}

--- a/Game/Assets/Shaders/drawLightTiles.shader
+++ b/Game/Assets/Shaders/drawLightTiles.shader
@@ -4,10 +4,12 @@ in vec2 uv;
 
 out vec4 color;
 
+uniform sampler2D sceneTexture;
+
 void main() {
 	ivec2 tile = ivec2(gl_FragCoord.xy) / ivec2(LIGHT_TILE_SIZE, LIGHT_TILE_SIZE);
 	int index = tile.x + tile.y * tilesPerRow;
 	float pointRatio = float(lightTiles.data[index].numPoints) / float(POINT_LIGHTS);
 	float spotRatio = float(lightTiles.data[index].numSpots) / float(SPOT_LIGHTS);
-	color = vec4(vec3(pointRatio, spotRatio, 0.0), 1.0);
+	color = vec4(vec3(0.0, spotRatio, 0.0), 1.0);
 }

--- a/Game/Assets/Shaders/drawLightTiles.shader
+++ b/Game/Assets/Shaders/drawLightTiles.shader
@@ -11,8 +11,6 @@ layout(std430, binding = 0) readonly buffer LightTilesBuffer
 
 uniform int tilesPerRow;
 
-uniform sampler2D sceneTexture;
-
 void main() {
 	ivec2 tile = ivec2(gl_FragCoord.xy) / ivec2(LIGHT_TILE_SIZE, LIGHT_TILE_SIZE);
 	int index = tile.x + tile.y * tilesPerRow;

--- a/Game/Assets/Shaders/drawLightTiles.shader
+++ b/Game/Assets/Shaders/drawLightTiles.shader
@@ -4,12 +4,18 @@ in vec2 uv;
 
 out vec4 color;
 
+layout(std430, binding = 0) readonly buffer LightTilesBuffer
+{
+	LightTile data[];
+} lightTilesBuffer;
+
+uniform int tilesPerRow;
+
 uniform sampler2D sceneTexture;
 
 void main() {
 	ivec2 tile = ivec2(gl_FragCoord.xy) / ivec2(LIGHT_TILE_SIZE, LIGHT_TILE_SIZE);
 	int index = tile.x + tile.y * tilesPerRow;
-	float pointRatio = float(lightTiles.data[index].numPoints) / float(POINT_LIGHTS);
-	float spotRatio = float(lightTiles.data[index].numSpots) / float(SPOT_LIGHTS);
-	color = vec4(vec3(0.0, spotRatio, 0.0), 1.0);
+	float lightRatio = float(lightTilesBuffer.data[index].count) / float(MAX_LIGHTS_PER_TILE);
+	color = vec4(vec3(lightRatio), 1.0);
 }

--- a/Game/Assets/Shaders/fragmentStandard.shader
+++ b/Game/Assets/Shaders/fragmentStandard.shader
@@ -179,9 +179,9 @@ float Shadow(vec4 lightPos, vec3 normal, vec3 lightDirection, sampler2D shadowMa
 
 --- fragVarLights
 
-#define POINT_LIGHTS 32
-#define SPOT_LIGHTS 8
-#define LIGHT_TILE_SIZE 32
+#define POINT_LIGHTS 64
+#define SPOT_LIGHTS 16
+#define LIGHT_TILE_SIZE 16
 
 struct DirLight
 {

--- a/Game/Assets/Shaders/lightCulling.shader
+++ b/Game/Assets/Shaders/lightCulling.shader
@@ -1,0 +1,236 @@
+--- varLights
+
+#define GRID_FRUSTUM_WORK_GROUP_SIZE 16
+#define LIGHT_TILE_SIZE 16
+#define MAX_LIGHTS_PER_TILE 1024
+
+struct Light
+{
+	vec3 pos;
+	int isSpotLight;
+	vec3 direction;
+	float intensity;
+	vec3 color;
+	float radius;
+	int useCustomFalloff;
+	float falloffExponent;
+	float innerAngle;
+	float outerAngle;
+};
+
+struct LightTile
+{
+	uint count;
+	uint offset;
+};
+
+struct TileFrustum
+{
+    vec3 planeNormals[4];
+};
+
+--- compGridFrustums
+
+layout(std430, binding = 0) writeonly buffer TileFrustumsBuffer
+{
+	TileFrustum data[];
+} tileFrustumsBuffer;
+
+uniform mat4 invProj;
+
+uniform vec2 screenSize;
+uniform uvec2 numThreads;
+
+layout(local_size_x = GRID_FRUSTUM_WORK_GROUP_SIZE, local_size_y = GRID_FRUSTUM_WORK_GROUP_SIZE, local_size_z = 1) in;
+void main()
+{
+    // Calculate normalized tile bounds
+    vec2 tileRects[4];
+    vec2 BiS2 = GRID_FRUSTUM_WORK_GROUP_SIZE * 2.0 / screenSize;
+    tileRects[0] = vec2(gl_GlobalInvocationID.xy) * BiS2 - 1.0; // Top left
+    tileRects[1] = vec2(gl_GlobalInvocationID.x + 1, gl_GlobalInvocationID.y) * BiS2 - 1.0; // Top right
+    tileRects[2] = vec2(gl_GlobalInvocationID.x, gl_GlobalInvocationID.y + 1) * BiS2 - 1.0; // Bottom left
+    tileRects[3] = vec2(gl_GlobalInvocationID.x + 1, gl_GlobalInvocationID.y + 1) * BiS2- 1.0; // Bottom right
+
+    // Calculate view space points (in far plane)
+    vec3 tileRectsVS[4];
+    for (int i = 0; i < 4; i++)
+    {
+        vec4 tileRectVS = invProj * vec4(tileRects[i], -1.0, 1.0);
+        tileRectsVS[i] = (tileRectVS / tileRectVS.w).xyz;
+    }
+
+    // Build the frustum plane normals
+    TileFrustum tileFrustum;
+    tileFrustum.planeNormals[0] = normalize(cross(tileRectsVS[2], tileRectsVS[0])); // Left
+    tileFrustum.planeNormals[1] = normalize(cross(tileRectsVS[1], tileRectsVS[3])); // Right
+    tileFrustum.planeNormals[2] = normalize(cross(tileRectsVS[0], tileRectsVS[1])); // Top
+    tileFrustum.planeNormals[3] = normalize(cross(tileRectsVS[3], tileRectsVS[2])); // Bottom
+
+    // Store the frustum
+    if (gl_GlobalInvocationID.x < numThreads.x && gl_GlobalInvocationID.y < numThreads.y)
+    {
+        uint index = gl_GlobalInvocationID.x + (gl_GlobalInvocationID.y * numThreads.x);
+        tileFrustumsBuffer.data[index] = tileFrustum;
+    }
+}
+
+--- compLightCulling
+
+layout(std430, binding = 0) readonly buffer TileFrustumsBuffer
+{
+	TileFrustum data[];
+} tileFrustumsBuffer;
+
+layout(std430, binding = 1) readonly buffer LightBuffer
+{
+	Light data[];
+} lightBuffer;
+
+layout(std430, binding = 2) buffer LightIndicesCountBuffer
+{
+	uint count;
+} lightIndicesCountBuffer;
+
+layout(std430, binding = 3) writeonly buffer LightIndicesBuffer
+{
+	uint data[];
+} lightIndicesBuffer;
+
+layout(std430, binding = 4) writeonly buffer LightTilesBuffer
+{
+	LightTile data[];
+} lightTilesBuffer;
+
+uniform mat4 invProj;
+uniform mat4 view;
+
+uniform vec2 screenSize;
+uniform int lightCount;
+
+uniform sampler2D depths;
+
+shared uint minDepthBits;
+shared uint maxDepthBits;
+shared TileFrustum tileFrustum;
+shared uint tileLightCount;
+shared uint tileIndexListOffset;
+shared uint tileLightIndices[MAX_LIGHTS_PER_TILE];
+
+void AddLightIndex(uint lightIndex)
+{
+    uint index = atomicAdd(tileLightCount, 1);
+    if (index < MAX_LIGHTS_PER_TILE)
+    {
+        tileLightIndices[index] = lightIndex;
+    }
+}
+
+float DepthToView(float depth)
+{
+    vec4 depthPoint = invProj * vec4(0.0, 0.0, depth, 1.0);
+    return depthPoint.z / depthPoint.w;
+}
+
+bool SphereInsidePlane(vec3 spherePosition, float sphereRadius, vec3 planeNormal, float planeDistance)
+{
+    return dot(planeNormal, spherePosition) - planeDistance < -sphereRadius;
+}
+
+bool SphereInsideTileFrustum(vec3 spherePosition, float sphereRadius, TileFrustum tileFrustum, float near, float far)
+{
+    bool isInsideFrustum = true;
+ 
+    if (spherePosition.z - sphereRadius > near || spherePosition.z + sphereRadius < far)
+    {
+        isInsideFrustum = false;
+    }
+ 
+    for (int i = 0; isInsideFrustum && i < 4; i++)
+    {
+        if (dot(tileFrustum.planeNormals[i], spherePosition) < -sphereRadius)
+        {
+            isInsideFrustum = false;
+        }
+    }
+ 
+    return isInsideFrustum;
+}
+
+float LinearizeDepth(float depth, float near, float far)
+{
+    return 2.0 * near * far / (far + near - (2.0 * depth - 1.0) * (far - near));
+}
+
+layout(local_size_x = LIGHT_TILE_SIZE, local_size_y = LIGHT_TILE_SIZE, local_size_z = 1) in;
+void main()
+{
+    // Get depth from depth texture and transform to uint bits
+    vec2 uv = vec2(gl_GlobalInvocationID.xy) / screenSize;
+    float depth = 2.0 * texture(depths, uv).r - 1.0;
+    uint depthBits = floatBitsToUint(depth);
+
+    // Initialize shared variables (only once)
+    if (gl_LocalInvocationIndex  == 0)
+    {
+        minDepthBits = 0xFFFFFFFF;
+        maxDepthBits = 0;
+        tileLightCount = 0;
+        uint index = gl_WorkGroupID.x + (gl_WorkGroupID.y * gl_NumWorkGroups.x);
+        tileFrustum = tileFrustumsBuffer.data[index];
+    }
+ 
+    barrier();
+
+    // Update min and max depths
+    atomicMin(minDepthBits, depthBits);
+    atomicMax(maxDepthBits, depthBits);
+
+    barrier();
+
+    // Cull lights
+    float minDepth = uintBitsToFloat(minDepthBits);
+    float maxDepth = uintBitsToFloat(maxDepthBits);
+ 
+    float minDepthVS = DepthToView(minDepth);
+    float maxDepthVS = DepthToView(maxDepth);
+    float nearPlaneVS = DepthToView(0.0);
+ 
+    vec3 minPlaneNormal = vec3(0, 0, -1);
+    float minPlaneDistance = -minDepthVS;
+
+    for (uint i = gl_LocalInvocationIndex; i < lightCount; i += LIGHT_TILE_SIZE * LIGHT_TILE_SIZE)
+    {
+        Light light = lightBuffer.data[i];
+        vec3 lightPosVS = (view * vec4(light.pos, 1.0)).xyz;
+        if (SphereInsideTileFrustum(lightPosVS, light.radius, tileFrustum, nearPlaneVS, maxDepthVS))
+        {
+            // TODO: Add transparent light list
+            // AddLightIndex(i);
+
+            if (!SphereInsidePlane(lightPosVS, light.radius, minPlaneNormal, minPlaneDistance))
+            {
+                AddLightIndex(i);
+            }
+        }
+    }
+
+    barrier();
+
+    // Reserve space in the index buffer and update tile
+    if (gl_LocalInvocationIndex == 0)
+    {
+        tileIndexListOffset = atomicAdd(lightIndicesCountBuffer.count, tileLightCount);
+        uint index = gl_WorkGroupID.x + (gl_WorkGroupID.y * gl_NumWorkGroups.x);
+        lightTilesBuffer.data[index].count = tileLightCount;
+        lightTilesBuffer.data[index].offset = tileIndexListOffset;
+    }
+
+    barrier();
+
+    // Write indices to index buffer
+    for (uint i = gl_LocalInvocationIndex; i < tileLightCount; i += LIGHT_TILE_SIZE * LIGHT_TILE_SIZE)
+    {
+        lightIndicesBuffer.data[tileIndexListOffset + i] = tileLightIndices[i];
+    }
+}

--- a/Game/Assets/Shaders/lightCulling.shader
+++ b/Game/Assets/Shaders/lightCulling.shader
@@ -62,10 +62,10 @@ void main()
 
     // Build the frustum plane normals
     TileFrustum tileFrustum;
-    tileFrustum.planeNormals[0] = normalize(cross(tileRectsVS[2], tileRectsVS[0])); // Left
-    tileFrustum.planeNormals[1] = normalize(cross(tileRectsVS[1], tileRectsVS[3])); // Right
-    tileFrustum.planeNormals[2] = normalize(cross(tileRectsVS[0], tileRectsVS[1])); // Top
-    tileFrustum.planeNormals[3] = normalize(cross(tileRectsVS[3], tileRectsVS[2])); // Bottom
+    tileFrustum.planeNormals[0] = normalize(cross(tileRectsVS[0], tileRectsVS[2])); // Left
+    tileFrustum.planeNormals[1] = normalize(cross(tileRectsVS[3], tileRectsVS[1])); // Right
+    tileFrustum.planeNormals[2] = normalize(cross(tileRectsVS[1], tileRectsVS[0])); // Top
+    tileFrustum.planeNormals[3] = normalize(cross(tileRectsVS[2], tileRectsVS[3])); // Bottom
 
     // Store the frustum
     if (gl_GlobalInvocationID.x < numThreads.x && gl_GlobalInvocationID.y < numThreads.y)

--- a/Game/Assets/Shaders/lightCulling.shader
+++ b/Game/Assets/Shaders/lightCulling.shader
@@ -157,11 +157,6 @@ bool SphereInsideTileFrustum(vec3 spherePosition, float sphereRadius, TileFrustu
     return isInsideFrustum;
 }
 
-float LinearizeDepth(float depth, float near, float far)
-{
-    return 2.0 * near * far / (far + near - (2.0 * depth - 1.0) * (far - near));
-}
-
 layout(local_size_x = LIGHT_TILE_SIZE, local_size_y = LIGHT_TILE_SIZE, local_size_z = 1) in;
 void main()
 {

--- a/Project/Source/Components/ComponentMeshRenderer.cpp
+++ b/Project/Source/Components/ComponentMeshRenderer.cpp
@@ -724,7 +724,7 @@ void ComponentMeshRenderer::Draw(const float4x4& modelMatrix) const {
 	}
 	glUniform1i(standardProgram->dirLightIsActiveLocation, directionalLight ? 1 : 0);
 
-	glUniform1i(standardProgram->tilesPerRowLocation, CeilInt(App->renderer->GetViewportSize().x / LIGHT_TILE_SIZE));
+	glUniform1i(standardProgram->tilesPerRowLocation, App->renderer->GetLightTilesPerRow());
 
 	glBindBuffer(GL_SHADER_STORAGE_BUFFER, App->renderer->lightTilesStorageBuffer);
 	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, App->renderer->lightTilesStorageBuffer);

--- a/Project/Source/Components/ComponentMeshRenderer.cpp
+++ b/Project/Source/Components/ComponentMeshRenderer.cpp
@@ -31,75 +31,6 @@
 #define JSON_TAG_MESH_ID "MeshID"
 #define JSON_TAG_MATERIAL_ID "MaterialID"
 
-#define POINT_LIGHT_MEMBERS 6
-#define POINT_LIGHT_STRING(number)                 \
-	{                                              \
-		"light.points["##number "].pos",           \
-			"light.points["##number "].color",     \
-			"light.points["##number "].intensity", \
-			"light.points["##number "].kc",        \
-			"light.points["##number "].kl",        \
-			"light.points["##number "].kq"         \
-	}
-
-#define SPOT_LIGHT_MEMBERS 9
-#define SPOT_LIGHT_STRING(number)                  \
-	{                                              \
-		"light.spots["##number "].pos",            \
-			"light.spots["##number "].direction",  \
-			"light.spots["##number "].color",      \
-			"light.spots["##number "].intensity",  \
-			"light.spots["##number "].kc",         \
-			"light.spots["##number "].kl",         \
-			"light.spots["##number "].kq",         \
-			"light.spots["##number "].innerAngle", \
-			"light.spots["##number "].outerAngle"  \
-	}
-
-static const char* pointLightStrings[POINT_LIGHTS][POINT_LIGHT_MEMBERS] = {
-	POINT_LIGHT_STRING("0"),
-	POINT_LIGHT_STRING("1"),
-	POINT_LIGHT_STRING("2"),
-	POINT_LIGHT_STRING("3"),
-	POINT_LIGHT_STRING("4"),
-	POINT_LIGHT_STRING("5"),
-	POINT_LIGHT_STRING("6"),
-	POINT_LIGHT_STRING("7"),
-	POINT_LIGHT_STRING("8"),
-	POINT_LIGHT_STRING("9"),
-	POINT_LIGHT_STRING("10"),
-	POINT_LIGHT_STRING("11"),
-	POINT_LIGHT_STRING("12"),
-	POINT_LIGHT_STRING("13"),
-	POINT_LIGHT_STRING("14"),
-	POINT_LIGHT_STRING("15"),
-	POINT_LIGHT_STRING("16"),
-	POINT_LIGHT_STRING("17"),
-	POINT_LIGHT_STRING("18"),
-	POINT_LIGHT_STRING("19"),
-	POINT_LIGHT_STRING("20"),
-	POINT_LIGHT_STRING("21"),
-	POINT_LIGHT_STRING("22"),
-	POINT_LIGHT_STRING("23"),
-	POINT_LIGHT_STRING("24"),
-	POINT_LIGHT_STRING("25"),
-	POINT_LIGHT_STRING("26"),
-	POINT_LIGHT_STRING("27"),
-	POINT_LIGHT_STRING("28"),
-	POINT_LIGHT_STRING("29"),
-	POINT_LIGHT_STRING("30"),
-	POINT_LIGHT_STRING("31")};
-
-static const char* spotLightStrings[SPOT_LIGHTS][SPOT_LIGHT_MEMBERS] = {
-	SPOT_LIGHT_STRING("0"),
-	SPOT_LIGHT_STRING("1"),
-	SPOT_LIGHT_STRING("2"),
-	SPOT_LIGHT_STRING("3"),
-	SPOT_LIGHT_STRING("4"),
-	SPOT_LIGHT_STRING("5"),
-	SPOT_LIGHT_STRING("6"),
-	SPOT_LIGHT_STRING("7")};
-
 ComponentMeshRenderer::~ComponentMeshRenderer() {
 	App->resources->DecreaseReferenceCount(meshId);
 	App->resources->DecreaseReferenceCount(materialId);
@@ -726,8 +657,9 @@ void ComponentMeshRenderer::Draw(const float4x4& modelMatrix) const {
 
 	glUniform1i(standardProgram->tilesPerRowLocation, App->renderer->GetLightTilesPerRow());
 
-	glBindBuffer(GL_SHADER_STORAGE_BUFFER, App->renderer->lightTilesStorageBuffer);
-	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, App->renderer->lightTilesStorageBuffer);
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, App->renderer->lightsStorageBuffer);
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, App->renderer->lightIndicesStorageBuffer);
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, App->renderer->lightTilesStorageBuffer);
 
 	glBindVertexArray(mesh->vao);
 	glDrawElements(GL_TRIANGLES, mesh->indices.size(), GL_UNSIGNED_INT, nullptr);

--- a/Project/Source/Globals.h
+++ b/Project/Source/Globals.h
@@ -69,6 +69,7 @@ enum class UpdateStatus {
 #define GLSL_VERSION "#version 460"
 #define POINT_LIGHTS 32
 #define SPOT_LIGHTS 8
+#define LIGHT_TILE_SIZE 32
 #define CASCADE_FRUSTUMS 10
 
 // Timers

--- a/Project/Source/Globals.h
+++ b/Project/Source/Globals.h
@@ -67,9 +67,9 @@ enum class UpdateStatus {
 
 // Configuration -----------
 #define GLSL_VERSION "#version 460"
-#define POINT_LIGHTS 32
-#define SPOT_LIGHTS 8
-#define LIGHT_TILE_SIZE 32
+#define POINT_LIGHTS 64
+#define SPOT_LIGHTS 16
+#define LIGHT_TILE_SIZE 16
 #define CASCADE_FRUSTUMS 10
 
 // Timers

--- a/Project/Source/Globals.h
+++ b/Project/Source/Globals.h
@@ -67,6 +67,8 @@ enum class UpdateStatus {
 
 // Configuration -----------
 #define GLSL_VERSION "#version 460"
+#define MAX_SCENE_COMPONENTS 10000
+#define MAX_LIGHTS 1000
 #define GRID_FRUSTUM_WORK_GROUP_SIZE 16
 #define LIGHT_TILE_SIZE 16
 #define MAX_LIGHTS_PER_TILE 1024

--- a/Project/Source/Globals.h
+++ b/Project/Source/Globals.h
@@ -67,9 +67,9 @@ enum class UpdateStatus {
 
 // Configuration -----------
 #define GLSL_VERSION "#version 460"
-#define POINT_LIGHTS 64
-#define SPOT_LIGHTS 16
+#define GRID_FRUSTUM_WORK_GROUP_SIZE 16
 #define LIGHT_TILE_SIZE 16
+#define MAX_LIGHTS_PER_TILE 1024
 #define CASCADE_FRUSTUMS 10
 
 // Timers

--- a/Project/Source/Modules/ModuleInput.cpp
+++ b/Project/Source/Modules/ModuleInput.cpp
@@ -19,7 +19,7 @@ bool ModuleInput::Init() {
 	bool ret = true;
 	SDL_Init(0);
 
-	if (SDL_InitSubSystem(SDL_INIT_EVENTS) < 0) {
+	if (SDL_InitSubSystem(SDL_INIT_EVENTS | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) < 0) {
 		LOG("SDL_EVENTS could not initialize! SDL_Error: %s\n", SDL_GetError());
 		ret = false;
 	}

--- a/Project/Source/Modules/ModuleInput.cpp
+++ b/Project/Source/Modules/ModuleInput.cpp
@@ -19,7 +19,7 @@ bool ModuleInput::Init() {
 	bool ret = true;
 	SDL_Init(0);
 
-	if (SDL_InitSubSystem(SDL_INIT_EVENTS | SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER | SDL_INIT_HAPTIC) < 0) {
+	if (SDL_InitSubSystem(SDL_INIT_EVENTS) < 0) {
 		LOG("SDL_EVENTS could not initialize! SDL_Error: %s\n", SDL_GetError());
 		ret = false;
 	}

--- a/Project/Source/Modules/ModulePrograms.cpp
+++ b/Project/Source/Modules/ModulePrograms.cpp
@@ -102,15 +102,15 @@ void ModulePrograms::LoadShaders() {
 	volumetricLight = new ProgramVolumetricLight(CreateProgram(filePath, "vertVolumetricLight", "gammaCorrection fragVolumetricLight"));
 
 	// General shaders
-	phongNotNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarStandard fragVarSpecular fragMainPhong"));
-	phongNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarStandard fragVarSpecular fragMainPhong"));
-	standardNotNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarStandard fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
-	standardNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarStandard fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
-	specularNotNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarStandard fragVarSpecular fragFunctionLight fragMainSpecular"));
-	specularNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarStandard fragVarSpecular fragFunctionLight fragMainSpecular"));
+	phongNotNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragMainPhong"));
+	phongNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragMainPhong"));
+	standardNotNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarLights fragVarStandard fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
+	standardNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
+	specularNotNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragFunctionLight fragMainSpecular"));
+	specularNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragFunctionLight fragMainSpecular"));
 
 	// Dissolve shaders. Maybe another one for Normals
-	dissolveStandard = new ProgramStandardDissolve(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarStandard fragVarMetallic fragFunctionLight fragFunctionDissolveCommon fragFunctionDissolveFunction fragMainMetallic"));
+	dissolveStandard = new ProgramStandardDissolve(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarMetallic fragFunctionLight fragFunctionDissolveCommon fragFunctionDissolveFunction fragMainMetallic"));
 	dissolveUnlit = new ProgramUnlitDissolve(CreateProgram(filePath, "vertUnlit", "gammaCorrection fragFunctionDissolveCommon fragFunctionDissolveFunction fragUnlit"));
 
 	// Depth Prepass Shaders
@@ -141,6 +141,7 @@ void ModulePrograms::LoadShaders() {
 
 	// Engine Shaders
 	drawTexture = new ProgramDrawTexture(CreateProgram(filePath, "vertScreen", "fragDrawTexture"));
+	drawLightTiles = new ProgramDrawLightTiles(CreateProgram(filePath, "vertScreen", "fragVarLights fragDrawLightTiles"));
 
 	// Particle Shaders
 	billboard = new ProgramBillboard(CreateProgram(filePath, "billboardVertex", "gammaCorrection billboardFragment"));
@@ -192,6 +193,7 @@ void ModulePrograms::UnloadShaders() {
 	RELEASE(imageUI);
 
 	RELEASE(drawTexture);
+	RELEASE(drawLightTiles);
 
 	RELEASE(billboard);
 	RELEASE(trail);

--- a/Project/Source/Modules/ModulePrograms.cpp
+++ b/Project/Source/Modules/ModulePrograms.cpp
@@ -95,6 +95,10 @@ void ModulePrograms::LoadShaders() {
 	environmentBRDF = new ProgramEnvironmentBRDF(CreateProgram(filePath, "vertScreen", "fragFunctionIBL fragEnvironmentBRDF"));
 	skybox = new ProgramSkybox(CreateProgram(filePath, "vertCube", "gammaCorrection fragSkybox"));
 
+	// Light culling shaders
+	gridFrustumsCompute = new ProgramGridFrustumsCompute(CreateComputeProgram(filePath, "varLights compGridFrustums"));
+	lightCullingCompute = new ProgramLightCullingCompute(CreateComputeProgram(filePath, "varLights compLightCulling"));
+
 	// Unlit Shader
 	unlit = new ProgramUnlit(CreateProgram(filePath, "vertUnlit", "gammaCorrection fragFunctionEmptyDissolve fragUnlit"));
 
@@ -102,15 +106,15 @@ void ModulePrograms::LoadShaders() {
 	volumetricLight = new ProgramVolumetricLight(CreateProgram(filePath, "vertVolumetricLight", "gammaCorrection fragVolumetricLight"));
 
 	// General shaders
-	phongNotNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragMainPhong"));
-	phongNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragMainPhong"));
-	standardNotNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarLights fragVarStandard fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
-	standardNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
-	specularNotNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragFunctionLight fragMainSpecular"));
-	specularNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarSpecular fragFunctionLight fragMainSpecular"));
+	phongNotNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection varLights fragVarStandard fragVarLights fragVarSpecular fragMainPhong"));
+	phongNormal = new ProgramStandardPhong(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection varLights fragVarStandard fragVarLights fragVarSpecular fragMainPhong"));
+	standardNotNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection varLights fragVarStandard fragVarLights fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
+	standardNormal = new ProgramStandardMetallic(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection varLights fragVarStandard fragVarLights fragVarMetallic fragFunctionLight fragFunctionEmptyDissolve fragMainMetallic"));
+	specularNotNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainCommon", "gammaCorrection varLights fragVarStandard fragVarLights fragVarSpecular fragFunctionLight fragMainSpecular"));
+	specularNormal = new ProgramStandardSpecular(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection varLights fragVarStandard fragVarLights fragVarSpecular fragFunctionLight fragMainSpecular"));
 
 	// Dissolve shaders. Maybe another one for Normals
-	dissolveStandard = new ProgramStandardDissolve(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection fragVarLights fragVarStandard fragVarMetallic fragFunctionLight fragFunctionDissolveCommon fragFunctionDissolveFunction fragMainMetallic"));
+	dissolveStandard = new ProgramStandardDissolve(CreateProgram(filePath, "vertVarCommon vertMainNormal", "gammaCorrection varLights fragVarStandard fragVarLights fragVarMetallic fragFunctionLight fragFunctionDissolveCommon fragFunctionDissolveFunction fragMainMetallic"));
 	dissolveUnlit = new ProgramUnlitDissolve(CreateProgram(filePath, "vertUnlit", "gammaCorrection fragFunctionDissolveCommon fragFunctionDissolveFunction fragUnlit"));
 
 	// Depth Prepass Shaders
@@ -141,7 +145,7 @@ void ModulePrograms::LoadShaders() {
 
 	// Engine Shaders
 	drawTexture = new ProgramDrawTexture(CreateProgram(filePath, "vertScreen", "fragDrawTexture"));
-	drawLightTiles = new ProgramDrawLightTiles(CreateProgram(filePath, "vertScreen", "fragVarLights fragDrawLightTiles"));
+	drawLightTiles = new ProgramDrawLightTiles(CreateProgram(filePath, "vertScreen", "varLights fragDrawLightTiles"));
 
 	// Particle Shaders
 	billboard = new ProgramBillboard(CreateProgram(filePath, "billboardVertex", "gammaCorrection billboardFragment"));
@@ -157,6 +161,9 @@ void ModulePrograms::UnloadShaders() {
 	RELEASE(preFilteredMap);
 	RELEASE(environmentBRDF);
 	RELEASE(skybox);
+
+	RELEASE(gridFrustumsCompute);
+	RELEASE(lightCullingCompute);
 
 	RELEASE(unlit);
 
@@ -218,6 +225,41 @@ unsigned ModulePrograms::CreateProgram(const char* shaderFile, const char* verte
 	unsigned programId = glCreateProgram();
 	glAttachShader(programId, vertexShader);
 	glAttachShader(programId, fragmentShader);
+	glLinkProgram(programId);
+	int res = GL_FALSE;
+	glGetProgramiv(programId, GL_LINK_STATUS, &res);
+	if (res == GL_FALSE) {
+		int len = 0;
+		glGetProgramiv(programId, GL_INFO_LOG_LENGTH, &len);
+		if (len > 0) {
+			int written = 0;
+			Buffer<char> info = Buffer<char>(len);
+			glGetProgramInfoLog(programId, len, &written, info.Data());
+			LOG("Program Log Info: %s", info.Data());
+		}
+
+		LOG("Error linking program.");
+	} else {
+		LOG("Program linked.");
+	}
+
+	return programId;
+}
+
+unsigned ModulePrograms::CreateComputeProgram(const char* shaderFile, const char* computeSnippets) {
+	LOG("Creating program...");
+
+	// Compile the shaders and delete them at the end
+	LOG("Compiling shaders...");
+	unsigned computeShader = CompileShader(GL_COMPUTE_SHADER, shaderFile, computeSnippets);
+	DEFER {
+		glDeleteShader(computeShader);
+	};
+
+	// Link the program
+	LOG("Linking program...");
+	unsigned programId = glCreateProgram();
+	glAttachShader(programId, computeShader);
 	glLinkProgram(programId);
 	int res = GL_FALSE;
 	glGetProgramiv(programId, GL_LINK_STATUS, &res);

--- a/Project/Source/Modules/ModulePrograms.h
+++ b/Project/Source/Modules/ModulePrograms.h
@@ -12,6 +12,7 @@ public:
 	void LoadShaders();
 	void UnloadShaders();
 	unsigned CreateProgram(const char* shaderFile, const char* vertexSnippets = "vertex", const char* fragmentSnippets = "fragment");
+	unsigned CreateComputeProgram(const char* shaderFile, const char* computeSnippets = "compute");
 	void DeleteProgram(unsigned int idProgram);
 
 public:
@@ -23,6 +24,10 @@ public:
 	ProgramPreFilteredMap* preFilteredMap = nullptr;
 	ProgramEnvironmentBRDF* environmentBRDF = nullptr;
 	ProgramSkybox* skybox = nullptr;
+
+	// Light culling shaders
+	ProgramGridFrustumsCompute* gridFrustumsCompute = nullptr;
+	ProgramLightCullingCompute* lightCullingCompute = nullptr;
 
 	// Unlit Shader
 	ProgramUnlit* unlit = nullptr;

--- a/Project/Source/Modules/ModulePrograms.h
+++ b/Project/Source/Modules/ModulePrograms.h
@@ -66,6 +66,7 @@ public:
 
 	// Engine Shaders
 	ProgramDrawTexture* drawTexture = nullptr;
+	ProgramDrawLightTiles* drawLightTiles = nullptr;
 
 	// UI Shaders
 	ProgramTextUI* textUI = nullptr;

--- a/Project/Source/Modules/ModuleRender.cpp
+++ b/Project/Source/Modules/ModuleRender.cpp
@@ -1117,7 +1117,8 @@ void ModuleRender::UpdateFramebuffers() {
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 
 	// Light tiles
-	lightTiles.resize(CeilInt(viewportSize.x / LIGHT_TILE_SIZE) * CeilInt(viewportSize.y / LIGHT_TILE_SIZE));
+	lightTilesPerRow = CeilInt(viewportSize.x / LIGHT_TILE_SIZE);
+	lightTiles.resize(lightTilesPerRow * CeilInt(viewportSize.y / LIGHT_TILE_SIZE));
 
 	// Render buffer
 	glBindFramebuffer(GL_FRAMEBUFFER, renderPassBuffer);
@@ -1357,6 +1358,10 @@ std::vector<GameObject*> ModuleRender::GetDynamicCulledShadowCasters(const Frust
 	}
 
 	return meshes;
+}
+
+int ModuleRender::GetLightTilesPerRow() const {
+	return lightTilesPerRow;
 }
 
 std::vector<GameObject*> ModuleRender::GetCulledMeshes(const FrustumPlanes& planes, const int mask) {
@@ -1613,7 +1618,7 @@ void ModuleRender::FillLightTiles() {
 			int maxTileY = Clamp(maxScreenY, 0, static_cast<int>(viewportSize.y) - 1) / LIGHT_TILE_SIZE;
 			for (int i = minTileX; i <= maxTileX; ++i) {
 				for (int j = minTileY; j <= maxTileY; ++j) {
-					LightTile& tile = lightTiles[i + j * CeilInt(viewportSize.x / LIGHT_TILE_SIZE)];
+					LightTile& tile = lightTiles[i + j * lightTilesPerRow];
 					if (light.lightType == LightType::POINT) {
 						if (tile.pointCount == POINT_LIGHTS) continue;
 						PointLight& lightStruct = tile.pointLights[tile.pointCount++];

--- a/Project/Source/Modules/ModuleRender.h
+++ b/Project/Source/Modules/ModuleRender.h
@@ -98,6 +98,8 @@ public:
 	std::vector<GameObject*> GetStaticCulledShadowCasters(const FrustumPlanes& planes) const;
 	std::vector<GameObject*> GetDynamicCulledShadowCasters(const FrustumPlanes& planes) const;
 
+	int GetLightTilesPerRow() const;
+
 	int GetCulledTriangles() const;
 	const float2 GetViewportSize();
 
@@ -230,6 +232,7 @@ private:
 	bool viewportUpdated = true;
 	float2 viewportSize = float2::zero;
 	float2 updatedViewportSize = float2::zero;
+	int lightTilesPerRow = 0;
 
 	unsigned int indexDepthMapTexture = -1;
 	ShadowCasterType shadowCasterType;

--- a/Project/Source/Modules/ModuleRender.h
+++ b/Project/Source/Modules/ModuleRender.h
@@ -233,6 +233,7 @@ private:
 	float2 viewportSize = float2::zero;
 	float2 updatedViewportSize = float2::zero;
 	int lightTilesPerRow = 0;
+	int lightTilesPerColumn = 0;
 
 	unsigned int indexDepthMapTexture = -1;
 	ShadowCasterType shadowCasterType;

--- a/Project/Source/Modules/ModuleScene.cpp
+++ b/Project/Source/Modules/ModuleScene.cpp
@@ -67,7 +67,7 @@ static void AssimpLogCallback(const char* message, char* user) {
 }
 
 bool ModuleScene::Init() {
-	scene = new Scene(10000);
+	scene = new Scene(MAX_SCENE_COMPONENTS);
 
 #ifdef _DEBUG
 	logStream.callback = AssimpLogCallback;

--- a/Project/Source/Panels/PanelScene.cpp
+++ b/Project/Source/Panels/PanelScene.cpp
@@ -31,7 +31,7 @@
 
 #include "Utils/Leaks.h"
 
-constexpr char* shadingMode[5] = {"Shaded", "Wireframe", "Ambient Occlusion", "Normals", "Positions"};
+constexpr char* shadingMode[6] = {"Shaded", "Wireframe", "Ambient Occlusion", "Normals", "Positions", "Light Tiles"};
 
 PanelScene::PanelScene()
 	: Panel("Scene", true) {}

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -299,8 +299,6 @@ ProgramDrawTexture::ProgramDrawTexture(unsigned program_)
 ProgramDrawLightTiles::ProgramDrawLightTiles(unsigned program_)
 	: Program(program_) {
 	tilesPerRowLocation = glGetUniformLocation(program, "tilesPerRow");
-
-	sceneTextureLocation = glGetUniformLocation(program, "sceneTexture");
 }
 
 ProgramImageUI::ProgramImageUI(unsigned program_)

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -126,7 +126,7 @@ ProgramStandard::ProgramStandard(unsigned program_)
 
 	viewOrtoLightsStaticLocation = glGetUniformLocation(program, "viewOrtoLightsStatic");
 	projOrtoLightsStaticLocation = glGetUniformLocation(program, "projOrtoLightsStatic");
-	
+
 	viewOrtoLightsDynamicLocation = glGetUniformLocation(program, "viewOrtoLightsDynamic");
 	projOrtoLightsDynamicLocation = glGetUniformLocation(program, "projOrtoLightsDynamic");
 
@@ -172,22 +172,14 @@ ProgramStandard::ProgramStandard(unsigned program_)
 	prefilteredIBLNumLevelsLocation = glGetUniformLocation(program, "prefilteredIBLNumLevels");
 	strengthIBLLocation = glGetUniformLocation(program, "strengthIBL");
 
-	lightAmbientColorLocation = glGetUniformLocation(program, "light.ambient.color");
+	ambientColorLocation = glGetUniformLocation(program, "ambientColor");
 
-	lightDirectionalDirectionLocation = glGetUniformLocation(program, "light.directional.direction");
-	lightDirectionalColorLocation = glGetUniformLocation(program, "light.directional.color");
-	lightDirectionalIntensityLocation = glGetUniformLocation(program, "light.directional.intensity");
-	lightDirectionalIsActiveLocation = glGetUniformLocation(program, "light.directional.isActive");
+	dirLightDirectionLocation = glGetUniformLocation(program, "dirLight.direction");
+	dirLightColorLocation = glGetUniformLocation(program, "dirLight.color");
+	dirLightIntensityLocation = glGetUniformLocation(program, "dirLight.intensity");
+	dirLightIsActiveLocation = glGetUniformLocation(program, "dirLight.isActive");
 
-	lightNumPointsLocation = glGetUniformLocation(program, "light.numPoints");
-	for (unsigned i = 0; i < POINT_LIGHTS; ++i) {
-		lightPoints[i] = PointLightUniforms(program, i);
-	}
-
-	lightNumSpotsLocation = glGetUniformLocation(program, "light.numSpots");
-	for (unsigned i = 0; i < SPOT_LIGHTS; ++i) {
-		lightSpots[i] = SpotLightUniforms(program, i);
-	}
+	tilesPerRowLocation = glGetUniformLocation(program, "tilesPerRow");
 }
 
 ProgramStandardPhong::ProgramStandardPhong(unsigned program_)
@@ -308,6 +300,11 @@ ProgramHeightFog::ProgramHeightFog(unsigned program_)
 ProgramDrawTexture::ProgramDrawTexture(unsigned program_)
 	: Program(program_) {
 	textureToDrawLocation = glGetUniformLocation(program, "textureToDraw");
+}
+
+ProgramDrawLightTiles::ProgramDrawLightTiles(unsigned program_)
+	: Program(program_) {
+	tilesPerRowLocation = glGetUniformLocation(program, "tilesPerRow");
 }
 
 ProgramImageUI::ProgramImageUI(unsigned program_)

--- a/Project/Source/Rendering/Programs.cpp
+++ b/Project/Source/Rendering/Programs.cpp
@@ -3,31 +3,6 @@
 #include "GL/glew.h"
 #include <string>
 
-PointLightUniforms::PointLightUniforms() {}
-
-PointLightUniforms::PointLightUniforms(unsigned program, unsigned number) {
-	posLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].pos").c_str());
-	colorLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].color").c_str());
-	intensityLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].intensity").c_str());
-	radiusLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].radius").c_str());
-	useCustomFalloffLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].useCustomFalloff").c_str());
-	falloffExponentLocation = glGetUniformLocation(program, (std::string("light.points[") + std::to_string(number) + "].falloffExponent").c_str());
-}
-
-SpotLightUniforms::SpotLightUniforms() {}
-
-SpotLightUniforms::SpotLightUniforms(unsigned program, unsigned number) {
-	posLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].pos").c_str());
-	directionLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].direction").c_str());
-	colorLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].color").c_str());
-	intensityLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].intensity").c_str());
-	radiusLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].radius").c_str());
-	useCustomFalloffLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].useCustomFalloff").c_str());
-	falloffExponentLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].falloffExponent").c_str());
-	innerAngleLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].innerAngle").c_str());
-	outerAngleLocation = glGetUniformLocation(program, (std::string("light.spots[") + std::to_string(number) + "].outerAngle").c_str());
-}
-
 Program::Program(unsigned program_)
 	: program(program_) {}
 
@@ -68,6 +43,25 @@ ProgramSkybox::ProgramSkybox(unsigned program_)
 	projLocation = glGetUniformLocation(program, "proj");
 
 	cubemapLocation = glGetUniformLocation(program, "cubemap");
+}
+
+ProgramGridFrustumsCompute::ProgramGridFrustumsCompute(unsigned program_)
+	: Program(program_) {
+	invProjLocation = glGetUniformLocation(program, "invProj");
+
+	screenSizeLocation = glGetUniformLocation(program, "screenSize");
+	numThreadsLocation = glGetUniformLocation(program, "numThreads");
+}
+
+ProgramLightCullingCompute::ProgramLightCullingCompute(unsigned program_)
+	: Program(program_) {
+	invProjLocation = glGetUniformLocation(program, "invProj");
+	viewLocation = glGetUniformLocation(program, "view");
+
+	screenSizeLocation = glGetUniformLocation(program, "screenSize");
+	lightCountLocation = glGetUniformLocation(program, "lightCount");
+
+	depthsLocation = glGetUniformLocation(program, "depths");
 }
 
 ProgramUnlit::ProgramUnlit(unsigned program_)
@@ -305,6 +299,8 @@ ProgramDrawTexture::ProgramDrawTexture(unsigned program_)
 ProgramDrawLightTiles::ProgramDrawLightTiles(unsigned program_)
 	: Program(program_) {
 	tilesPerRowLocation = glGetUniformLocation(program, "tilesPerRow");
+
+	sceneTextureLocation = glGetUniformLocation(program, "sceneTexture");
 }
 
 ProgramImageUI::ProgramImageUI(unsigned program_)

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -86,6 +86,25 @@ struct ProgramSkybox : Program {
 	int cubemapLocation = -1;
 };
 
+struct ProgramGridFrustumsCompute : Program {
+	ProgramGridFrustumsCompute(unsigned program);
+
+	int invProjLocation = -1;
+	int screenSizeLocation = -1;
+	int numThreadsLocation = -1;
+};
+
+struct ProgramLightCullingCompute : Program {
+	ProgramLightCullingCompute(unsigned program);
+
+	int invProjLocation = -1;
+	int viewLocation = -1;
+	int screenSizeLocation = -1;
+	int lightCountLocation = -1;
+
+	int depthsLocation = -1;
+};
+
 struct ProgramUnlit : public Program {
 	ProgramUnlit(unsigned program);
 
@@ -334,6 +353,8 @@ struct ProgramDrawLightTiles : Program {
 	ProgramDrawLightTiles(unsigned program);
 
 	int tilesPerRowLocation = -1;
+
+	int sceneTextureLocation = -1;
 };
 
 struct ProgramImageUI : Program {

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -188,18 +188,14 @@ struct ProgramStandard : public Program {
 	int prefilteredIBLNumLevelsLocation = -1;
 	int strengthIBLLocation = -1;
 
-	int lightAmbientColorLocation = -1;
+	int ambientColorLocation = -1;
 
-	int lightDirectionalDirectionLocation = -1;
-	int lightDirectionalColorLocation = -1;
-	int lightDirectionalIntensityLocation = -1;
-	int lightDirectionalIsActiveLocation = -1;
+	int dirLightDirectionLocation = -1;
+	int dirLightColorLocation = -1;
+	int dirLightIntensityLocation = -1;
+	int dirLightIsActiveLocation = -1;
 
-	PointLightUniforms lightPoints[POINT_LIGHTS];
-	int lightNumPointsLocation = -1;
-
-	SpotLightUniforms lightSpots[POINT_LIGHTS];
-	int lightNumSpotsLocation = -1;
+	int tilesPerRowLocation = -1;
 };
 
 struct ProgramStandardPhong : ProgramStandard {
@@ -332,6 +328,12 @@ struct ProgramDrawTexture : Program {
 	ProgramDrawTexture(unsigned program);
 
 	int textureToDrawLocation = -1;
+};
+
+struct ProgramDrawLightTiles : Program {
+	ProgramDrawLightTiles(unsigned program);
+
+	int tilesPerRowLocation = -1;
 };
 
 struct ProgramImageUI : Program {

--- a/Project/Source/Rendering/Programs.h
+++ b/Project/Source/Rendering/Programs.h
@@ -353,8 +353,6 @@ struct ProgramDrawLightTiles : Program {
 	ProgramDrawLightTiles(unsigned program);
 
 	int tilesPerRowLocation = -1;
-
-	int sceneTextureLocation = -1;
 };
 
 struct ProgramImageUI : Program {

--- a/Project/Source/Resources/ResourceScene.cpp
+++ b/Project/Source/Resources/ResourceScene.cpp
@@ -34,7 +34,7 @@ void ResourceScene::Load() {
 
 	// Create scene
 	JsonValue jScene = JsonValue(document, document);
-	scene = new Scene(10000);
+	scene = new Scene(MAX_SCENE_COMPONENTS);
 	scene->Load(jScene);
 
 	unsigned timeMs = timer.Stop();


### PR DESCRIPTION
This PR includes an implementation of Forward+ tiled rendering using compute shaders. This saves around 4ms on average. This also allows a much higher amount of lights.

There may be a few artifacts left, mostly when rendering transparent objects.

![image](https://imgur.com/7K5FWHc.png)