### PR TITLE
Fix import deadlock crash

### DIFF
--- a/Project/Source/Modules/ModuleResources.cpp
+++ b/Project/Source/Modules/ModuleResources.cpp
@@ -156,11 +156,15 @@ void ModuleResources::ReceiveEvent(TesseractEvent& e) {
 		UID id = e.Get<DestroyResourceStruct>().resourceId;
 		resourcesMutex.lock();
 		auto& it = resources.find(id);
+		std::unique_ptr<Resource> resource = nullptr;
 		if (it != resources.end()) {
-			UnloadResource(it->second.get());
+			resource.swap(it->second);
 			resources.erase(it);
 		}
 		resourcesMutex.unlock();
+		if (resource.get() != nullptr) {
+			UnloadResource(resource.get());
+		}
 	} else if (e.type == TesseractEventType::UPDATE_ASSET_CACHE) {
 		AssetCache* newAssetCache = e.Get<UpdateAssetCacheStruct>().assetCache;
 		assetCache.reset(newAssetCache);


### PR DESCRIPTION
This fixes a crash that happened quite often when reloading materials.