### PR TITLE
ComponentSelectable is no longer selectable if Not Active or Not Interactable

### DIFF
--- a/Project/Source/Components/UI/ComponentSelectable.cpp
+++ b/Project/Source/Components/UI/ComponentSelectable.cpp
@@ -343,6 +343,7 @@ bool ComponentSelectable::IsClicked() const {
 }
 
 void ComponentSelectable::TryToClickOn(bool internalClick) const {
+	if (!IsActive() || !IsInteractable()) return; //Cannot be clicked on if not active/not interactable
 	UID toBeClicked = 0;
 	ComponentType typeToPress = ComponentType::UNKNOWN;
 


### PR DESCRIPTION
This code prevents some unwanted interactions.