### PR TITLE
ComponentSlider must stop being handled on disable.

### DIFF
--- a/Project/Source/Components/UI/ComponentSlider.cpp
+++ b/Project/Source/Components/UI/ComponentSlider.cpp
@@ -147,6 +147,11 @@ void ComponentSlider::OnEditorUpdate() {
 	ImGui::ColorEdit4("Manual Input Color##", colorManualInput.ptr());
 }
 
+void ComponentSlider::OnDisable() {
+	beingHandled = false;
+	App->userInterface->handlingSlider = false;
+}
+
 void ComponentSlider::OnClicked() {
 	//Does nothing, as the functionaliy happens onClickDown (OnClickedInternal method)
 }

--- a/Project/Source/Components/UI/ComponentSlider.h
+++ b/Project/Source/Components/UI/ComponentSlider.h
@@ -23,6 +23,7 @@ public:
 	void Init() override; // Component Initialization
 	void Update() override;
 	void OnEditorUpdate() override; // Input for class variables
+	void OnDisable() override;
 
 	void OnClicked() override;
 	void OnClickedInternal() override;


### PR DESCRIPTION
This hotfix prevents a navigation error if you start handling a slider and then hide the navigation elements by unpausing.